### PR TITLE
make Tooltip's `hoverDelay` optional

### DIFF
--- a/src/components/BaseBadge.tsx
+++ b/src/components/BaseBadge.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Flex from 'components/Flex';
-import Text, { TextProps } from 'components/Text';
+import Text from 'components/Text';
+import { BaseTextProps } from 'components/BaseText';
 
-export interface BaseBadgeProps extends TextProps {
+export interface BaseBadgeProps extends BaseTextProps {
   /** The color theme of the badge */
   color: 'neutral' | 'grey' | 'blue' | 'pink' | 'red';
 }

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -76,7 +76,9 @@ export interface ComboboxProps<T> {
  * A simple Combobox can be thought of as a typical `<select>` component. Whenerever you would
  * use a normal select, you should now pass the `<Combobox>` component.
  */
-const Combobox: <T = any>(props: ComboboxProps<T>) => React.ReactElement<ComboboxProps<T>> = ({
+const Combobox: <ItemShape>(
+  props: ComboboxProps<ItemShape>
+) => React.ReactElement<ComboboxProps<ItemShape>> = ({
   onChange,
   value,
   items,

--- a/src/components/MultiCombobox.tsx
+++ b/src/components/MultiCombobox.tsx
@@ -117,9 +117,9 @@ const stateReducer = (state: DownshiftState<any>, changes: StateChangeOptions<an
  * A simple MultiCombobox can be thought of as a typical `<select>` component. Whenerever you would
  * use a normal select, you should now pass the `<MultiCombobox>` component.
  */
-const MultiCombobox: <T = any>(
-  props: MultiComboboxProps<T>
-) => React.ReactElement<MultiComboboxProps<T>> = ({
+const MultiCombobox: <ItemShape>(
+  props: MultiComboboxProps<ItemShape>
+) => React.ReactElement<MultiComboboxProps<ItemShape>> = ({
   onChange,
   value,
   items,

--- a/src/components/Table.md
+++ b/src/components/Table.md
@@ -4,7 +4,7 @@ almost all things.
 
 You have to provide a `name` and a `key` to each column. The `name` is by
 default the label that each column header will show. The `key` is a unique identifier for the
-column. If you dont add a `renderItem` prop in a column, the Table attempts to show the value of the
+column. If you dont add a `renderCell` prop in a column, the Table attempts to show the value of the
 `key` field for a particular item. Thus, whenever you don't want to add a custom rendering (but
 just display the text as it is) you should make sure that the column `key` matches the "key" of the
 item that this column refers to.

--- a/src/components/Table.md
+++ b/src/components/Table.md
@@ -1,6 +1,15 @@
 The Table is one of the non-trivial components due to the sheer amount of
 abilities it has. Study the API carefully and you will see that you have the ability to override
-almost all things:
+almost all things.
+
+You have to provide a `name` and a `key` to each column. The `name` is by
+default the label that each column header will show. The `key` is a unique identifier for the
+column. If you dont add a `renderItem` prop in a column, the Table attempts to show the value of the
+`key` field for a particular item. Thus, whenever you don't want to add a custom rendering (but
+just display the text as it is) you should make sure that the column `key` matches the "key" of the
+item that this column refers to.
+
+The examples below showcase that functionality.
 
 A table can be simple:
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -7,11 +7,9 @@ import Text from 'components/Text';
 import BaseButton from 'components/BaseButton';
 import Icon from 'components/Icon';
 
-export type TableItem = { [key: string]: any };
+export type TableItem<T> = { [key: string]: T };
 
-export type TableItemKeyShape = number | string;
-
-export type ColumnProps = {
+export type ColumnProps<T> = {
   /** A unique identifier for this particular column */
   key: string;
 
@@ -42,16 +40,16 @@ export type ColumnProps = {
    * will be put as the content of each cell in the column. If it's not defined then Table will use
    * the value of `item[key]`
    * */
-  renderCell?: (item: TableItem, index: number) => React.ReactNode;
+  renderCell?: (item: TableItem<T>, index: number) => React.ReactNode;
 };
 
-export type TableProps = {
+export type TableProps<T> = {
   /**
-   * A list of items that are going to be showcased by the Table. TableItem extends the basic JS
-   * object, thus the shape of these items can by anything. Usually they keep the same
-   * shape as the one that was returned from the API.
+   * A list of items that are going to be showcased by the Table. TableItem has a default value of
+   * any, thus it can have any shape. Usually it keeps the same shape as the one that was returned
+   * from the API.
    */
-  items: TableItem[];
+  items: TableItem<T>[];
 
   /** A function that gets an item as param and should return a unique identifier for each item. This
    * prop helps with uniquely identifying an item in the Table in order to optimise re-renders. If
@@ -59,13 +57,13 @@ export type TableProps = {
    *
    * As a general rule, always try to define this prop
    * */
-  getItemKey?: (item: TableItem) => TableItemKeyShape;
+  getItemKey?: (item: TableItem<T>) => number | string;
 
   /**
    * A list of column object that describe each column. More info on the shape of these objects
    * follows down below
    * */
-  columns: ColumnProps[];
+  columns: ColumnProps<T>[];
 
   /** Whether the table should show the table's headers or not. */
   showHeaders?: boolean;
@@ -77,13 +75,13 @@ export type TableProps = {
    * This is a callback for when the user clicks on one of the headers of the columns that are
    * sortable. If the column is not sortable, then nothing happens.
    */
-  onSort?: (key: ColumnProps['key']) => void;
+  onSort?: (key: ColumnProps<T>['key']) => void;
 
   /**
    * The currently active sort key. This is a controlled prop that should match the `key` prop
    * defined in each column object.
    * */
-  sortKey?: ColumnProps['key'] | null;
+  sortKey?: ColumnProps<T>['key'] | null;
 
   /** The currently active sort direction. This is a controlled prop. */
   sortDir?: 'ascending' | 'descending' | undefined;
@@ -92,7 +90,7 @@ export type TableProps = {
    * Callback that fires whenever the row is selected either through a click event. There are
    * plans to support keyboard navigation.
    * */
-  onSelect?: (item: TableItem) => void;
+  onSelect?: (item: TableItem<T>) => void;
 };
 
 /**
@@ -116,7 +114,7 @@ const Row: React.FC<FlexProps> = ({ children, ...rest }) => (
 );
 
 /** The typical Table component with additional functionality */
-const Table: React.FC<TableProps> = ({
+export function Table<ItemShape>({
   items,
   columns,
   getItemKey,
@@ -127,8 +125,8 @@ const Table: React.FC<TableProps> = ({
   sortDir,
   onSelect,
   ...rest
-}) => {
-  const renderTableHeader = (column: ColumnProps) => {
+}: TableProps<ItemShape>): React.ReactElement<TableProps<ItemShape>> {
+  const renderTableHeader = (column: ColumnProps<ItemShape>) => {
     // Get the base component
     let content = column.renderColumnHeader ? (
       column.renderColumnHeader(sortKey === column.key)
@@ -164,7 +162,11 @@ const Table: React.FC<TableProps> = ({
     );
   };
 
-  const renderTableItem = (column: ColumnProps, item: TableItem, index: number) => {
+  const renderTableItem = (
+    column: ColumnProps<ItemShape>,
+    item: TableItem<ItemShape>,
+    index: number
+  ) => {
     return (
       <Cell key={column.key} role="cell" flex={column.flex}>
         {column.renderCell ? (
@@ -193,7 +195,7 @@ const Table: React.FC<TableProps> = ({
       ))}
     </Box>
   );
-};
+}
 
 Table.defaultProps = {
   getItemKey: undefined,

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -7,7 +7,7 @@ import Text from 'components/Text';
 import BaseButton from 'components/BaseButton';
 import Icon from 'components/Icon';
 
-export type TableItem = { [key: string]: string | number | null | undefined };
+export type TableItem = { [key: string]: any };
 
 export type TableItemKeyShape = number | string;
 

--- a/src/components/Tooltip.md
+++ b/src/components/Tooltip.md
@@ -41,3 +41,17 @@ import Text from 'components/Text';
   <Text>I'll allow you to hover my tooltip</Text>
 </Tooltip>;
 ```
+
+Lastly, by default the Tooltip appears after a brief delay, but you can make it appear instantly:
+
+```jsx harmony
+import IconButton from 'components/IconButton';
+import Icon from 'components/Icon';
+import Label from 'components/Label';
+
+<Tooltip hoverDelay={0} content={<Label size="medium">I appear instantly</Label>}>
+  <IconButton variant="primary">
+    <Icon type="user" size="large" />
+  </IconButton>
+</Tooltip>;
+```

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -13,7 +13,7 @@ export interface TooltipProps {
   allowHover?: boolean;
 
   /** How much should it wait before showing the tooltip */
-  hoverDelay: number;
+  hoverDelay?: number;
 }
 
 /** A tooltip is a helper that shows some helping text when hovering or clicking something */

--- a/src/utils/useEnumerableTableRows.tsx
+++ b/src/utils/useEnumerableTableRows.tsx
@@ -2,21 +2,21 @@ import React from 'react';
 import { TableProps } from 'components/Table';
 import Label from 'components/Label';
 
-export interface UseEnumerableTableRowsProps {
+export interface UseEnumerableTableRowsProps<T> {
   /**
    * A list of column object that describe each column. More info on the shape of these objects
    * follows down below
    * */
-  columns: TableProps['columns'];
+  columns: TableProps<T>['columns'];
 }
 
 /**
  * A hook that extends the columns of a table in order to add an enumeration column to show the
  * serial number of each row
  * */
-const useEnumerableTableRows = ({ columns }: UseEnumerableTableRowsProps) => {
+function useEnumerableTableRows<ItemShape>({ columns }: UseEnumerableTableRowsProps<ItemShape>) {
   /* eslint-disable react/display-name */
-  const extendedColumns: TableProps['columns'] = React.useMemo(
+  const extendedColumns: TableProps<ItemShape>['columns'] = React.useMemo(
     () => [
       {
         key: 'enumeration',
@@ -35,6 +35,6 @@ const useEnumerableTableRows = ({ columns }: UseEnumerableTableRowsProps) => {
   /* eslint-enable react/display-name */
 
   return extendedColumns;
-};
+}
 
 export default useEnumerableTableRows;

--- a/src/utils/useSelectableTableRows.tsx
+++ b/src/utils/useSelectableTableRows.tsx
@@ -2,42 +2,46 @@ import React from 'react';
 import { TableProps } from 'components/Table';
 import Checkbox from 'components/Checkbox';
 
-export interface UseSelectableTableRowsProps {
+export interface UseSelectableTableRowsProps<T> {
   /**
    * A list of items that are going to be showcased by the Table. TableItem extends the basic JS
    * object, thus the shape of these items can by anything. Usually they keep the same
    * shape as the one that was returned from the API.
    */
-  items: TableProps['items'];
+  items: TableProps<T>['items'];
 
   /**
    * A list of column object that describe each column. More info on the shape of these objects
    * follows down below
    * */
-  columns: TableProps['columns'];
+  columns: TableProps<T>['columns'];
 
   /**
    * This is a callback for when the user clicks on one of checkboxes. This should only be defined
    * if "selectable" is true, since it won't have any effect if checkboxes are not present.
    */
-  onSelect: (selectedItems: TableProps['items']) => void;
+  onSelect: (selectedItems: TableProps<T>['items']) => void;
 }
 
 /**
  * A variation of the table where a first column is added in order to show the serial number of
  * each row
  * */
-const useSelectableTableRows = ({ columns, onSelect, items }: UseSelectableTableRowsProps) => {
-  const [selectedItems, setSelectedItems] = React.useState<UseSelectableTableRowsProps['items']>(
-    []
-  );
+function useSelectableTableRows<ItemShape>({
+  columns,
+  onSelect,
+  items,
+}: UseSelectableTableRowsProps<ItemShape>) {
+  const [selectedItems, setSelectedItems] = React.useState<
+    UseSelectableTableRowsProps<ItemShape>['items']
+  >([]);
 
   React.useEffect(() => {
     onSelect(selectedItems);
   }, [selectedItems]);
 
   /* eslint-disable react/display-name */
-  const extendedColumns: TableProps['columns'] = React.useMemo(
+  const extendedColumns: TableProps<ItemShape>['columns'] = React.useMemo(
     () => [
       {
         key: 'selection',
@@ -70,6 +74,6 @@ const useSelectableTableRows = ({ columns, onSelect, items }: UseSelectableTable
   /* eslint-enable react/display-name */
 
   return extendedColumns;
-};
+}
 
 export default useSelectableTableRows;


### PR DESCRIPTION
### Background

The `hoverDelay` should not be a required prop since it should be more transparent to the basic user

### Changes

- Make `hoverDelay` an optional prop
- Allow the value of items in a table to have `any` type (to align with every type of data that the user has)
- `BadgeProps` now extends `BaseTextProps` in order not to require the `size` prop from the Text component
- Enhance docs on `Table` component
- Add generics to `Table`
- Rename generic prop in `Combobox` and `MultiCombobox`

### Testing

- Typescript should not complain if you don't specify a `hoverDelay` on a `<Tooltip />` component
