### PR TITLE
fix(basebutton): add `text-decoration: none` to all

### DIFF
--- a/src/components/BaseButton.tsx
+++ b/src/components/BaseButton.tsx
@@ -13,6 +13,7 @@ const BaseButton: React.FC<BaseButtonProps> = props => (
     is="button"
     css={css`
       cursor: pointer;
+      text-decoration: none;
       transition: all 0.1s linear;
 
       &[disabled] {


### PR DESCRIPTION
this is to protect against links disguised as buttons
