### PR TITLE
build(npm): add npm releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    "@semantic-release/github",
+    "@semantic-release/npm"
   ]
 }


### PR DESCRIPTION
### Background

This PR adds NPM plugin to the releasing process, so we can install pounce from NPM as well

### Changes

- Add npm to semantic release plugins

### Testing

- Local
