### PR TITLE
fix: mark pkg as public

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "module": "dist/index.esm.js",
   "sideEffects": false,
-  "private": true,
+  "private": false,
   "keywords": [
     "react",
     "components",


### PR DESCRIPTION
### Background

Package should be publicly accessible

### Changes

-  Mark pkg as public in `package.json`

### Testing

- N/A
