### PR TITLE
Restrict Alert module

### DIFF
--- a/src/components/AbstractButton/AbstractButton.mdx
+++ b/src/components/AbstractButton/AbstractButton.mdx
@@ -1,0 +1,22 @@
+Composes <a href="/#/PseudoBox">PseudoBox</a>.
+
+The `AbstractButton` is a component that's not opinionated in terms of UI but encapsulates the
+basic responsibilities of a button.
+
+Use this component to wrap something that's clickable just like a button, but it doesn't
+look like a typical button (in which case you would have used `<Button>`).
+
+An AbstractButton can wrap anything without affecting the styling:
+
+```typescript jsx
+<Box>
+  Click the image
+  <br />
+  <AbstractButton onClick={() => alert('clicked')}>
+    <img
+      src="https://avatars2.githubusercontent.com/u/10436045?s=400&u=09293d4486f1fd66ee75d014821062c20b33e13e&v=4"
+      alt="avatar"
+    />
+  </AbstractButton>
+</Box>
+```

--- a/src/components/Alert/Alert.mdx
+++ b/src/components/Alert/Alert.mdx
@@ -2,10 +2,18 @@ Alerts can be simple:
 
 ```typescript jsx
 <Box width={1} bg="grey50" p={5}>
-  <Alert variant="success" mb={3} title="This is an success alert" />
-  <Alert variant="info" mb={3} title="This is an info alert" />
-  <Alert variant="warning" mb={3} title="This is a warning alert" />
-  <Alert variant="error" title="This is an error alert" />
+  <Box mb={3}>
+    <Alert variant="success" mb={3} title="This is an success alert" />{' '}
+  </Box>
+  <Box mb={3}>
+    <Alert variant="info" mb={3} title="This is an info alert" />{' '}
+  </Box>
+  <Box mb={3}>
+    <Alert variant="warning" mb={3} title="This is a warning alert" />{' '}
+  </Box>
+  <Box>
+    <Alert variant="error" title="This is an error alert" />
+  </Box>
 </Box>
 ```
 
@@ -13,10 +21,18 @@ Alerts can contain icons:
 
 ```typescript jsx
 <Box width={1} bg="grey50" p={5}>
-  <Alert icon="check" variant="success" mb={3} title="This is an success alert" />
-  <Alert icon="edit" variant="info" mb={3} title="This is an info alert" />
-  <Alert icon="warning" variant="warning" mb={3} title="This is a warning alert" />
-  <Alert icon="delete" variant="error" title="This is an error alert" />
+  <Box mb={3}>
+    <Alert icon="check" variant="success" title="This is an success alert" />
+  </Box>
+  <Box mb={3}>
+    <Alert icon="edit" variant="info" title="This is an info alert" />
+  </Box>
+  <Box mb={3}>
+    <Alert icon="warning" variant="warning" title="This is a warning alert" />
+  </Box>
+  <Box>
+    <Alert icon="delete" variant="error" title="This is an error alert" />
+  </Box>
 </Box>
 ```
 
@@ -24,33 +40,38 @@ Alerts can have descriptions:
 
 ```typescript jsx
 <Box width={1} bg="grey50" p={5}>
-  <Alert
-    icon="check"
-    variant="success"
-    mb={3}
-    title="This is an success alert"
-    description="This is a nice description of the title"
-  />
-  <Alert
-    icon="edit"
-    variant="info"
-    mb={3}
-    title="This is an info alert"
-    description="This is a nice description of the title"
-  />
-  <Alert
-    icon="warning"
-    variant="warning"
-    mb={3}
-    title="This is a warning alert"
-    description="This is a nice description of the title"
-  />
-  <Alert
-    icon="delete"
-    variant="error"
-    title="This is an error alert"
-    description="This is a nice description of the title"
-  />
+  <Box mb={3}>
+    <Alert
+      icon="check"
+      variant="success"
+      title="This is an success alert"
+      description="This is a nice description of the title"
+    />
+  </Box>
+  <Box mb={3}>
+    <Alert
+      icon="edit"
+      variant="info"
+      title="This is an info alert"
+      description="This is a nice description of the title"
+    />
+  </Box>
+  <Box mb={3}>
+    <Alert
+      icon="warning"
+      variant="warning"
+      title="This is a warning alert"
+      description="This is a nice description of the title"
+    />
+  </Box>
+  <Box>
+    <Alert
+      icon="delete"
+      variant="error"
+      title="This is an error alert"
+      description="This is a nice description of the title"
+    />
+  </Box>
 </Box>
 ```
 
@@ -58,36 +79,41 @@ Alerts can be hidden by the user:
 
 ```typescript jsx
 <Box width={1} bg="grey50" p={5}>
-  <Alert
-    icon="check"
-    variant="success"
-    mb={3}
-    title="This is an success alert"
-    description="This is a nice description of the title"
-    discardable
-  />
-  <Alert
-    icon="edit"
-    variant="info"
-    mb={3}
-    title="This is an info alert"
-    description="This is a nice description of the title"
-    discardable
-  />
-  <Alert
-    icon="warning"
-    variant="warning"
-    mb={3}
-    title="This is a warning alert"
-    description="This is a nice description of the title"
-    discardable
-  />
-  <Alert
-    icon="delete"
-    variant="error"
-    title="This is an error alert"
-    description="This is a nice description of the title"
-    discardable
-  />
+  <Box mb={3}>
+    <Alert
+      icon="check"
+      variant="success"
+      title="This is an success alert"
+      description="This is a nice description of the title"
+      discardable
+    />
+  </Box>
+  <Box mb={3}>
+    <Alert
+      icon="edit"
+      variant="info"
+      title="This is an info alert"
+      description="This is a nice description of the title"
+      discardable
+    />
+  </Box>
+  <Box mb={3}>
+    <Alert
+      icon="warning"
+      variant="warning"
+      title="This is a warning alert"
+      description="This is a nice description of the title"
+      discardable
+    />
+  </Box>
+  <Box mb={3}>
+    <Alert
+      icon="delete"
+      variant="error"
+      title="This is an error alert"
+      description="This is a nice description of the title"
+      discardable
+    />
+  </Box>
 </Box>
 ```

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -7,7 +7,7 @@ import IconButton from '../IconButton';
 import Icon from '../Icon';
 import { icons } from '../../theme';
 
-export interface AlertProps extends Omit<BoxProps, 'title'> {
+export interface AlertProps {
   /** The style of the Alert */
   variant: 'success' | 'info' | 'warning' | 'error';
 
@@ -22,6 +22,9 @@ export interface AlertProps extends Omit<BoxProps, 'title'> {
 
   /** Whether the Alert should have a close button in order to remove itself */
   discardable?: boolean;
+
+  /** Adjusts the padding of the related Alert. Defaults to `large` */
+  size?: 'small' | 'medium' | 'large';
 }
 
 /** An Alert component is simply a container for text that should capture the user's attention */
@@ -31,6 +34,7 @@ const Alert: React.FC<AlertProps> = ({
   variant,
   icon,
   discardable,
+  size = 'large',
   ...rest
 }) => {
   const [open, setOpen] = React.useState(true);
@@ -47,7 +51,19 @@ const Alert: React.FC<AlertProps> = ({
       default:
         return { borderColor: 'red300', color: 'red300' };
     }
-  })() as Partial<AlertProps>;
+  })() as Pick<BoxProps, 'color' | 'borderColor'>;
+
+  const sizeProps = (function() {
+    switch (size) {
+      case 'small':
+        return { py: 0, px: 3 };
+      case 'medium':
+        return { py: 2, px: 5 };
+      case 'large':
+      default:
+        return { py: 4, px: 7 };
+    }
+  })();
 
   // Progressively override/enhance the rendered structure based on the optional props provided.
   // Order of checks matters a lot here
@@ -90,10 +106,9 @@ const Alert: React.FC<AlertProps> = ({
   return open ? (
     <Card
       position="relative"
-      py={4}
-      px={7}
       borderLeft="3px solid"
       borderColor={variantProps.borderColor}
+      {...sizeProps}
       {...rest}
     >
       {content}

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -25,7 +25,7 @@ const Snackbar: React.FC<SnackbarProps> = ({ destroy, duration, ...rest }) => {
     return () => clearTimeout(timeoutRef.current);
   }, []);
 
-  return <Alert py={2} discardable {...rest} />;
+  return <Alert size="medium" discardable {...rest} />;
 };
 
 Snackbar.defaultProps = {

--- a/src/components/Snackbar/SnackbarContext.tsx
+++ b/src/components/Snackbar/SnackbarContext.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Flex from '../Flex';
 import Snackbar, { SnackbarProps } from '../Snackbar';
 import { isBrowser } from '../../utils/helpers';
+import Box from '../Box';
 
 const generateSnackbarId = () =>
   Math.random()
@@ -85,7 +86,9 @@ export const SnackbarProvider: React.FC = ({ children }) => {
         zIndex={9999}
       >
         {snackbars.map(({ id, ...snackbarPublicProps }) => (
-          <Snackbar mb={3} key={id} destroy={() => removeSnackbar(id)} {...snackbarPublicProps} />
+          <Box mb={3} key={id}>
+            <Snackbar destroy={() => removeSnackbar(id)} {...snackbarPublicProps} />
+          </Box>
         ))}
       </Flex>,
       document.body


### PR DESCRIPTION
### Background

Currently, Alert accepts all kinds of props which makes it hard to reason about when it comes to what it "can" and "cannot" do. 

This PR restricts the alert props to its native ones, dissallowing to add props which would be (up until now) forwarded to the underlying Card component 

### Changes

- Add `size` prop
- Restrict Alert types

### Testing

- Tested on docs page
