### PR TITLE
Fix safari intersection observer polyfill dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1515,6 +1515,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@juggle/resize-observer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.2.0.tgz",
+      "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@emotion/react": "^11.0.0-next.12",
     "@emotion/styled": "^11.0.0-next.12",
+    "@juggle/resize-observer": "^3.2.0",
     "@reach/dialog": "^0.10.3",
     "@reach/menu-button": "^0.10.3",
     "@reach/tabs": "^0.10.3",

--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import useMeasure from 'react-use-measure';
+import { ResizeObserver } from '@juggle/resize-observer';
 import { animated, useTransition } from 'react-spring';
 import Box, { BoxProps } from '../Box';
 
@@ -37,7 +38,7 @@ const Collapse: React.FC<CollapseProps> = ({
   children,
   ...rest
 }) => {
-  const [ref, { height }] = useMeasure();
+  const [ref, { height }] = useMeasure({ polyfill: ResizeObserver });
 
   const transitions = useTransition(open, null, {
     from: { height: 0, opacity: animateOpacity ? 0 : 1 },

--- a/src/components/Snackbar/SnackbarContext.tsx
+++ b/src/components/Snackbar/SnackbarContext.tsx
@@ -1,10 +1,11 @@
 import React, { useContext } from 'react';
 import ReactDOM from 'react-dom';
+import { ResizeObserver } from '@juggle/resize-observer';
+import { animated, useTransition } from 'react-spring';
+import useMeasure from 'react-use-measure';
 import Flex from '../Flex';
 import Snackbar, { SnackbarProps } from '../Snackbar';
 import { isBrowser } from '../../utils/helpers';
-import { animated, useTransition } from 'react-spring';
-import useMeasure from 'react-use-measure';
 import Box from '../Box';
 
 type SnackbarContextValue = {
@@ -95,7 +96,7 @@ export const SnackbarProvider: React.FC = ({ children }) => {
     return id;
   };
 
-  const [ref, { height }] = useMeasure({ debounce: 100, scroll: false });
+  const [ref, { height }] = useMeasure({ debounce: 100, scroll: false, polyfill: ResizeObserver });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const transitions = useTransition<SnackbarStateShape, any>(


### PR DESCRIPTION
### Background

As `react-use-measure` [docs](https://github.com/react-spring/react-use-measure/#%EF%B8%8F-notes) suggest the hook requires a polyfill in order to properly work with Safari. The repo was not properly working and the webpack error tracking was complaining on startup. This PR adds the polyfill as suggested.

![Screenshot 2020-07-07 at 12 37 53 PM](https://user-images.githubusercontent.com/1022166/86771593-2eec0c80-c05b-11ea-9d8a-519b69b46242.png)

### Changes

- Add the [juggle/resize-observer](https://github.com/juggle/resize-observer) as suggested to `package.json` and `package-lock.json`
- Patch the `useMeasure` React hook to consume the polyfill 

### Testing

- Check out the master branch, run `npm i` and `npm run start`
- Open the app in Safari (I am currently using the version 13.0.5 which does not support the [resize observer](https://caniuse.com/#feat=resizeobserver)
- Check out the PR branch, once more run run `npm i` and `npm run start`
- The Snackbar component should work as expected with no errors or warnings.
- You can also test the changes in the main `panther` repo as follows: 
  - Go to `pounce` repo and run `npm pack` a `pouncejs-0.0.0-semantically-released.tgz` should get created at the root of the project
  - Replace the actual `pouncejs` entry in your `package.json` with the absolute path targeting the tarball created in the previous step, e.g `"pouncejs": "/Users/theodore/Desktop/pounce/pouncejs-0.0.0-semantically-released.tgz"`
  - Run  `npm i` and `npm run start` and open the panther app, everything should be working as expected with no errors or warnings.