### PR TITLE
fix: issue with JSDom and TextAreaAutosize

### DIFF
--- a/src/components/utils/Input/InputElement.tsx
+++ b/src/components/utils/Input/InputElement.tsx
@@ -26,7 +26,7 @@ const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
         fontSize="medium"
         fontWeight="medium"
         backgroundColor="transparent"
-        border="none"
+        border={0}
         _disabled={{
           opacity: 1, // we have nested disabled elements, so we don't want lower opacities to multiply
         }}


### PR DESCRIPTION

### Background

Having `border: none` messed up with height measurements  in jsdom. Making it be `0` fixes that.

### Changes

- Change `border: none` to `border: 0`

### Testing

- N/A
