### PR TITLE
Feat: add `outline` style for `IconButton`

### DIFF
--- a/src/components/IconButton/IconButton.mdx
+++ b/src/components/IconButton/IconButton.mdx
@@ -23,7 +23,7 @@ An Iconbutton can be solid and have different sizes:
 </Box>
 ```
 
-An IconButton can be ghost:
+An IconButton can be `ghost`:
 
 ```typescript jsx
 <SimpleGrid columns={4} gap={4}>
@@ -31,6 +31,17 @@ An IconButton can be ghost:
   <IconButton variant="ghost" icon="user" aria-label="User" variantColor="teal" />
   <IconButton variant="ghost" icon="user" aria-label="User" variantColor="navyblue" active />
   <IconButton variant="ghost" icon="user" aria-label="User" variantColor="teal" active />
+</SimpleGrid>
+```
+
+An IconButton can be `outline`:
+
+```typescript jsx
+<SimpleGrid columns={4} gap={4}>
+  <IconButton variant="outline" icon="user" aria-label="User" variantColor="navyblue" />
+  <IconButton variant="outline" icon="user" aria-label="User" variantColor="teal" />
+  <IconButton variant="outline" icon="user" aria-label="User" variantColor="navyblue" active />
+  <IconButton variant="outline" icon="user" aria-label="User" variantColor="teal" active />
 </SimpleGrid>
 ```
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -15,7 +15,7 @@ export interface IconButtonProps extends NativeAttributes<'button'>, Pick<BoxPro
   icon: IconProps['type'];
 
   /** The style of the icon button */
-  variant?: 'solid' | 'ghost' | 'unstyled';
+  variant?: 'solid' | 'ghost' | 'outline' | 'unstyled';
 
   /** The color scheme of the button for solid variants */
   variantColor?:

--- a/src/components/IconButton/useIconButtonStyles.tsx
+++ b/src/components/IconButton/useIconButtonStyles.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { addOpacity } from '../../utils/helpers';
+import { addOpacity, lightenDarkenColor } from '../../utils/helpers';
 import { AbstractButtonProps } from '../AbstractButton';
 import { getSolidButtonStyles, getThemeColor } from '../Button/useButtonStyles';
 import useTheme from '../../utils/useTheme';
@@ -15,6 +15,35 @@ export const getUnstyledButtonStyles = (theme: Theme) => {
     _focus: {
       borderRadius: 'circle' as const,
       backgroundColor: addOpacity(theme.colors.white, 0.1),
+    },
+  };
+};
+
+const getOutlineButtonStyles = (theme: Theme, variantColor: ButtonColorVariant) => {
+  const themeColorKey = getThemeColor(variantColor);
+  const themeColor = theme.colors[themeColorKey];
+
+  const hoverColor = lightenDarkenColor(themeColor, 8);
+  const activeColor = lightenDarkenColor(themeColor, -25);
+  const focusBorderColor = lightenDarkenColor(themeColor, 85);
+
+  return {
+    transition: 'border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms, background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms', // prettier-ignore
+    borderRadius: 'circle' as const,
+    border: '1px solid',
+    borderColor: themeColor,
+    backgroundColor: 'transparent',
+    _hover: {
+      backgroundColor: hoverColor,
+      borderColor: hoverColor,
+    },
+    _focus: {
+      backgroundColor: hoverColor,
+      borderColor: focusBorderColor,
+    },
+    _active: {
+      backgroundColor: activeColor,
+      borderColor: activeColor,
     },
   };
 };
@@ -54,6 +83,8 @@ const useIconButtonStyles = ({
         return getGhostButtonStyles(theme, variantColor);
       case 'unstyled':
         return getUnstyledButtonStyles(theme);
+      case 'outline':
+        return getOutlineButtonStyles(theme, variantColor);
       case 'solid':
       default:
         return getSolidButtonStyles(theme, variantColor);


### PR DESCRIPTION
### Background

Adds a new style to  `IconButton`  to align with the design needs

### Changes

- add same `outline` styling as the `Button` already has

### Design Needs

https://app.abstract.com/projects/558a8de6-7134-4c8b-91c5-62074bb1279b/branches/849670d3-62c0-462f-b399-bf6174c4352b/commits/d4746ddd93986a63d5e9fd960cccbd3e2acd2db8/files/3cc6ad23-a286-4d07-a10b-a9852419c176/layers/C8D76341-DF55-4723-A268-27B7FB3B5D70?collectionId=bf397f88-46df-4162-ba27-ae65dae0f98c&collectionLayerId=a25bc457-e96c-4525-98a6-b3e762c2b9f5&mode=design

### Testing

- N/A, Can be seen at `{DOCS_URL}/#/IconButton`