### PR TITLE
Feat: add new default breakpoints  to pounce

### DIFF
--- a/src/components/Box/Box.mdx
+++ b/src/components/Box/Box.mdx
@@ -21,6 +21,14 @@ A Box with the red font color and huge font-size:
 </Box>
 ```
 
+A Box that has a responsive width according to the screen size:
+
+```typescript jsx
+<Box p={9} bg="red-200" width={[300, 600, 900]} fontSize="2x-large">
+  Box
+</Box>
+```
+
 A Box can also implement other components under the hood and accept its props:
 
 ```typescript jsx

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -22,7 +22,7 @@ export interface Theme extends StyledSystemTheme {
 }
 
 export const theme: Theme = {
-  breakpoints: ['1200px'],
+  breakpoints: ['769px', '1366px'],
   space: [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40],
   radii: {
     none: 0,


### PR DESCRIPTION
### Background

Pounce had a single breakpoint for small & large screens. Adding a new one for large-mobiles & tablets in an effort to help with responsiveness

### Changes

- Add new breakpoints to pounce's default theme

### Testing

- Through docs & examplees
