### PR TITLE
Fix: Input number proper `onChange` event

### DIFF
--- a/src/components/NumberInput/NumberInput.mdx
+++ b/src/components/NumberInput/NumberInput.mdx
@@ -2,13 +2,13 @@ An input can be valid:
 
 ```typescript jsx
 const Example = () => {
-  const [value, setValue] = React.useState();
+  const [value, setValue] = React.useState(0);
   return (
     <NumberInput
       label="Minutes"
       placeholder="Type a number..."
       value={value}
-      onChange={e => setValue(e.target.value)}
+      onInputNumberChange={v => setValue(v)}
     />
   );
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -65,3 +65,5 @@ export function slugify(text: string) {
  * @returns True if current environment is a browser, false in any other case
  */
 export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
+export const noop = (): void => {};


### PR DESCRIPTION
### Background

Since the `<input type="number" />` does not properly handle the `onChange` events when [`HTMLInputElement.stepUp`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/stepUp) or [`HTMLInputElement.stepDown`](HTMLInputElement.stepDown) methods are getting invoked we need to make the actual component controlled, thus we need to create a custom callback. 

### Changes

- Added `onInputNumberChange` for `NumberInput` component.

### Testing

- Manually and visually through `styleguidist`
