### PR TITLE
fix: add missing colors for pounce theme

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -5,6 +5,10 @@ const colors = {
   white: '#ffffff',
   black: '#000000',
 
+  'white-100': '#ffffff',
+  'white-200': '#f6f6f6',
+  'white-300': '#fefefe',
+
   'navyblue-100': '#86a3c3',
   'navyblue-200': '#4f627c',
   'navyblue-300': '#3e516b',


### PR DESCRIPTION
### Background

As described added 3 missing colors as designed. No side-effects introduced.