### PR TITLE
feat: add styling to tabs

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -3,12 +3,24 @@ import { Tab as ReachTab } from '@reach/tabs';
 import AbstractButton from '../AbstractButton';
 import { NativeAttributes } from '../Box';
 import { ComponentWithAs } from '@reach/utils';
+import useTabStyles from './useTabStyles';
 
-export type TabProps = NativeAttributes<'button'> & { disabled?: boolean };
+export type TabProps = NativeAttributes<'button'> & {
+  /** Whether the tab should be disabled */
+  disabled?: boolean;
 
-const Tab = React.forwardRef<HTMLButtonElement, TabProps>(function Tab({ children, ...rest }, ref) {
+  /** @ignore internal index of the tab in relation to its siblings */
+  index: number;
+};
+
+const Tab = React.forwardRef<HTMLButtonElement, TabProps>(function Tab(
+  { children, index, ...rest },
+  ref
+) {
+  const styles = useTabStyles({ index });
+
   return (
-    <ReachTab ref={ref} as={AbstractButton} {...rest}>
+    <ReachTab ref={ref} as={AbstractButton} {...styles} {...rest}>
       {children}
     </ReachTab>
   );

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -9,12 +9,18 @@ const FlexList = React.forwardRef<HTMLUListElement, FlexProps>(function FlexList
   return <Flex as="ul" flexWrap="wrap" ref={ref} {...props} />;
 });
 
-export const TabList = React.forwardRef<HTMLUListElement, TabListProps>(function TabList(
-  props,
+export const TabList = React.forwardRef<HTMLInputElement, TabListProps>(function TabList(
+  { children, ...rest },
   ref
 ) {
-  // @ts-ignore Typing is wrong on @reach-ui, allowing only div | undefined for `as`
-  return <ReachTabList as={FlexList} ref={ref} {...props} />;
+  return (
+    // @ts-ignore Typing is wrong on @reach-ui, allowing only div | undefined for `as`
+    <ReachTabList as={FlexList} ref={ref} {...rest}>
+      {React.Children.map(children, (child, index) =>
+        React.cloneElement(child as React.ReactElement, { index })
+      )}
+    </ReachTabList>
+  );
 });
 
 export default TabList;

--- a/src/components/Tabs/useTabStyles.tsx
+++ b/src/components/Tabs/useTabStyles.tsx
@@ -1,0 +1,37 @@
+import { useTabsContext } from '@reach/tabs';
+import { AbstractButtonProps } from '../AbstractButton';
+
+interface UseTabStylesProps {
+  index: number;
+}
+
+const useTabStyles = ({ index }: UseTabStylesProps): Partial<AbstractButtonProps> => {
+  const { focusedIndex, selectedIndex } = useTabsContext();
+
+  const selectedColor = 'blue-400';
+  const focusedColor = 'navyblue-300';
+
+  const isSelected = selectedIndex === index;
+  const isFocused = focusedIndex === index;
+
+  let borderColor: AbstractButtonProps['borderColor'];
+  if (isSelected) {
+    borderColor = selectedColor;
+  } else if (isFocused) {
+    borderColor = focusedColor;
+  } else {
+    borderColor = 'transparent';
+  }
+
+  return {
+    outline: 'none',
+    borderBottom: '3px solid',
+    transition: 'border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
+    _hover: {
+      borderColor: !isSelected ? focusedColor : undefined,
+    },
+    borderColor,
+  };
+};
+
+export default useTabStyles;


### PR DESCRIPTION
### Background

Lots of designs have tabs that have the same styling applied to them. This PR adds this styling on pounce so that  apps like Panther can use them without any trouble.

### Screenshots
<img width="998" alt="Screen Shot 2020-08-04 at 3 20 08 PM" src="https://user-images.githubusercontent.com/10436045/89293583-d4000200-d666-11ea-9533-7233effdd2c2.png">


### Changes

- Pass an `index` prop from `TabList` to  all `Tab`  components to help with styling
- Create  `useTabStyles` local hook to handle  all styling
- Use hook in `Tab` components

### Testing

- Testing steps
