### PR TITLE
Fix issues with tab focuses

### DIFF
--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import { TabList as ReachTabList } from '@reach/tabs';
-import Flex, { FlexProps } from '../Flex';
 import { NativeAttributes } from '../Box';
+import PseudoBox, { PseudoBoxProps } from '../PseudoBox';
 
 export type TabListProps = NativeAttributes<'ul'>;
 
-const FlexList = React.forwardRef<HTMLUListElement, FlexProps>(function FlexList(props, ref) {
-  return <Flex as="ul" flexWrap="wrap" ref={ref} {...props} />;
+const FlexList = React.forwardRef<HTMLUListElement, PseudoBoxProps>(function FlexList(props, ref) {
+  return (
+    <PseudoBox
+      ref={ref}
+      as="ul"
+      display="flex"
+      flexWrap="wrap"
+      _after={{
+        content: '""',
+        width: '100%',
+        height: '1px',
+        backgroundColor: 'navyblue-300',
+        marginTop: '-2px',
+      }}
+      {...props}
+    />
+  );
 });
 
 export const TabList = React.forwardRef<HTMLInputElement, TabListProps>(function TabList(

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -1,6 +1,7 @@
-import { TabPanel as ReachTabPanel, TabPanelProps as ReachTabPanelProps } from '@reach/tabs';
+import React from 'react';
+import { TabPanel as ReachTabPanel } from '@reach/tabs';
+import Box from '../Box';
 
-export type TabPanelProps = ReachTabPanelProps;
-export const TabPanel = ReachTabPanel;
+const TabPanel: React.FC = props => <Box as={ReachTabPanel} tabIndex={-1} {...props} />;
 
 export default TabPanel;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -8,4 +8,3 @@ export type { TabsProps } from './Tabs';
 export type { TabListProps } from './TabList';
 export type { TabProps } from './Tab';
 export type { TabPanelsProps } from './TabPanels';
-export type { TabPanelProps } from './TabPanel';

--- a/src/components/Tabs/useTabStyles.tsx
+++ b/src/components/Tabs/useTabStyles.tsx
@@ -24,7 +24,7 @@ const useTabStyles = ({ index }: UseTabStylesProps): Partial<AbstractButtonProps
   }
 
   return {
-    outline: 'none',
+    zIndex: 1,
     borderBottom: '3px solid',
     transition: 'border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
     _hover: {


### PR DESCRIPTION
### Background

Currently tabs are not "outlined" when a user users the `<tab>` key. At the same time, when you tab, the entire tabpanel gets focused which you probably don't want that.

This PR fixes that by making sure focus is handled correctly. Also it  adds a missing border below the tabs (SS)

### Screenshots

Problematic focusing can be seen here

<img width="943" alt="Screen Shot 2020-08-04 at 5 09 11 PM" src="https://user-images.githubusercontent.com/10436045/89313700-8775f000-d681-11ea-8602-da3afe3e21f4.png">

A new border has been added 

<img width="1012" alt="Screen Shot 2020-08-04 at 5 15 15 PM" src="https://user-images.githubusercontent.com/10436045/89313795-a2486480-d681-11ea-91e1-358adcb5a4fc.png">


### Changes

- Add border
- Re-instate tab outline
- Remove tab panel focus

### Testing

- Visual
