### PR TITLE
fix: add zIndex to modal's close button

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -72,7 +72,7 @@ const Modal: React.FC<ModalProps> = ({
                       </Box>
                     )}
                     {showCloseButton && (
-                      <Box position="absolute" top={3} right={3}>
+                      <Box position="absolute" top={3} right={3} zIndex={1}>
                         <IconButton
                           icon="close"
                           aria-label="Dismiss Dialog"


### PR DESCRIPTION
### Background

When we have complex content (somethign other than just a text) in the Modal's header, the close button is sitting behind it and can't be clicked. This PR fixes that  byy making sure that the modal's button is always in the front

### Changes

- Add `zIndex: 1` to modal's close button container

### Testing

- Manual
