### PR TITLE
fix: link color according to latest design lib updates

### DIFF
--- a/src/components/Link/useLinkStyles.tsx
+++ b/src/components/Link/useLinkStyles.tsx
@@ -1,13 +1,9 @@
 import { LinkProps } from './Link';
 import { PseudoBoxProps } from '../PseudoBox';
-import useTheme from '../../utils/useTheme';
-import { lightenDarkenColor } from '../../utils/helpers';
 
 type UseLinkStyles = Pick<LinkProps, 'variant'>;
 
 const useLinkStyles = ({ variant }: UseLinkStyles): PseudoBoxProps => {
-  const theme = useTheme();
-
   switch (variant) {
     case 'neutral':
       return {
@@ -30,15 +26,14 @@ const useLinkStyles = ({ variant }: UseLinkStyles): PseudoBoxProps => {
       };
     case 'prominent':
     default: {
-      const hoverColor = lightenDarkenColor(theme.colors['blue-400'], 25);
       return {
         transition: `color 0.1s ease-out`,
         fontWeight: 'medium',
         textDecoration: 'none',
-        color: 'blue-400',
-        _hover: { color: hoverColor },
-        _focus: { color: hoverColor },
-        _active: { color: hoverColor },
+        color: 'blue-200',
+        _hover: { color: 'blue-100' },
+        _focus: { color: 'blue-100' },
+        _active: { color: 'blue-300' },
       };
     }
   }


### PR DESCRIPTION
### Background

Users have complained that the color of the link is not easy to read given the "dark" background that it normally sits on. This prompted our designs to change in order to lighten the colors of the links

### Design

https://app.abstract.com/projects/ab14d6c7-511b-4577-8de9-25ca9cd2918b/branches/master/commits/adef37090241a6512e10d5d9cbd9688409fc076f/files/80211ea4-8009-417c-883f-6c096a2959bb/layers/008E0080-642C-4F61-9632-19A8CFD0E76D?mode=build&selected=root-A9FEF646-EAB4-4A36-91B7-FBFF9BBDE29C

### Screenshots

<img width="1017" alt="Screen Shot 2020-08-06 at 10 04 37 AM" src="https://user-images.githubusercontent.com/10436045/89501591-42120980-d7cc-11ea-9219-889d4a0e55b4.png">


### Changes

- Change link colors

### Testing

- Visual
