### PR TITLE
fix: Input labels

### DIFF
--- a/src/components/Combobox/Combobox.mdx
+++ b/src/components/Combobox/Combobox.mdx
@@ -26,7 +26,7 @@ const Example1 = () => {
       <Box width={0.5}>
         <Combobox
           label="Choose a moto manufacturer"
-          labelHidden
+          hideLabel
           placeholder="Choose a motorcycle manufacturer"
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
           onChange={updateSelectedMoto}

--- a/src/components/Combobox/Combobox.mdx
+++ b/src/components/Combobox/Combobox.mdx
@@ -10,7 +10,7 @@ A Combobox can be basic:
 
 ```typescript jsx
 const Example1 = () => {
-  const [selecteCar, updateSelectedCar] = React.useState(null);
+  const [selectedCar, updateSelectedCar] = React.useState(null);
   const [selectedMoto, updateSelectedMoto] = React.useState(null);
   return (
     <>
@@ -19,12 +19,14 @@ const Example1 = () => {
           label="Choose a car manufacturer"
           items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
           onChange={updateSelectedCar}
-          value={selecteCar}
+          value={selectedCar}
           placeholder="Select a manufacturer"
         />
       </Box>
       <Box width={0.5}>
         <Combobox
+          label="Choose a moto manufacturer"
+          labelHidden
           placeholder="Choose a motorcycle manufacturer"
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
           onChange={updateSelectedMoto}

--- a/src/components/Combobox/Combobox.mdx
+++ b/src/components/Combobox/Combobox.mdx
@@ -10,17 +10,28 @@ A Combobox can be basic:
 
 ```typescript jsx
 const Example1 = () => {
-  const [selectedItems, updateSelectedItems] = React.useState(null);
+  const [selecteCar, updateSelectedCar] = React.useState(null);
+  const [selectedMoto, updateSelectedMoto] = React.useState(null);
   return (
-    <Box width={0.3}>
-      <Combobox
-        label="Choose a car manufacturer"
-        items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
-        onChange={updateSelectedItems}
-        value={selectedItems}
-        placeholder="Select a manufacturer"
-      />
-    </Box>
+    <>
+      <Box width={0.4} mr={4}>
+        <Combobox
+          label="Choose a car manufacturer"
+          items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
+          onChange={updateSelectedCar}
+          value={selecteCar}
+          placeholder="Select a manufacturer"
+        />
+      </Box>
+      <Box width={0.5}>
+        <Combobox
+          placeholder="Choose a motorcycle manufacturer"
+          items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
+          onChange={updateSelectedMoto}
+          value={selectedMoto}
+        />
+      </Box>
+    </>
   );
 };
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -17,7 +17,7 @@ export type ComboboxProps<T> = {
   items: T[];
 
   /** The label that is associated with this combobox */
-  label: string;
+  label?: string;
 
   /**
    * A function that converts the an item to a string. This is the value that the dropdown will
@@ -178,12 +178,15 @@ function Combobox<Item>({
                   as="input"
                   type="text"
                   truncated
+                  standalone={!label}
                   pr={8} /* account for absolute position of caret */
                   {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
                 />
-                <InputLabel raised={value != null} {...getLabelProps()}>
-                  {label}
-                </InputLabel>
+                {label && (
+                  <InputLabel raised={value != null} {...getLabelProps()}>
+                    {label}
+                  </InputLabel>
+                )}
               </InputControl>
               <Icon
                 opacity={disabled ? 0.3 : 1}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -20,7 +20,7 @@ export type ComboboxProps<T> = {
   label: string;
 
   /** Whether the label should get visually hidden */
-  labelHidden?: boolean;
+  hideLabel?: boolean;
 
   /**
    * A function that converts the an item to a string. This is the value that the dropdown will
@@ -79,7 +79,7 @@ function Combobox<Item>({
   items,
   searchable = false,
   label = '',
-  labelHidden,
+  hideLabel,
   disabled = false,
   disableItem = () => false,
   itemToString = item => String(item),
@@ -182,16 +182,12 @@ function Combobox<Item>({
                   as="input"
                   type="text"
                   truncated
-                  standalone={labelHidden}
+                  standalone={hideLabel}
                   pr={8} /* account for absolute position of caret */
                   {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
                 />
 
-                <InputLabel
-                  visuallyHidden={labelHidden}
-                  raised={value != null}
-                  {...getLabelProps()}
-                >
+                <InputLabel visuallyHidden={hideLabel} raised={value != null} {...getLabelProps()}>
                   {label}
                 </InputLabel>
               </InputControl>

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -17,7 +17,10 @@ export type ComboboxProps<T> = {
   items: T[];
 
   /** The label that is associated with this combobox */
-  label?: string;
+  label: string;
+
+  /** Whether the label should get visually hidden */
+  labelHidden?: boolean;
 
   /**
    * A function that converts the an item to a string. This is the value that the dropdown will
@@ -76,6 +79,7 @@ function Combobox<Item>({
   items,
   searchable = false,
   label = '',
+  labelHidden,
   disabled = false,
   disableItem = () => false,
   itemToString = item => String(item),
@@ -178,15 +182,18 @@ function Combobox<Item>({
                   as="input"
                   type="text"
                   truncated
-                  standalone={!label}
+                  standalone={labelHidden}
                   pr={8} /* account for absolute position of caret */
                   {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
                 />
-                {label && (
-                  <InputLabel raised={value != null} {...getLabelProps()}>
-                    {label}
-                  </InputLabel>
-                )}
+
+                <InputLabel
+                  visuallyHidden={labelHidden}
+                  raised={value != null}
+                  {...getLabelProps()}
+                >
+                  {label}
+                </InputLabel>
               </InputControl>
               <Icon
                 opacity={disabled ? 0.3 : 1}

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -26,7 +26,7 @@ const Example3 = () => {
       <Box width={0.5}>
         <MultiCombobox
           label="Choose a car manufacturer"
-          labelHidden
+          hideLabel
           placeholder="Choose a motorcycle manufacturer"
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
           onChange={updateSelectedMoto}

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -10,17 +10,30 @@ A MultiCombobox can be basic:
 
 ```typescript jsx
 const Example3 = () => {
-  const [selectedItems, updateSelectedItems] = React.useState([]);
+  const [selectedCar, updateSelectedCar] = React.useState([]);
+  const [selectedMoto, updateSelectedMoto] = React.useState([]);
   return (
-    <Box width={0.3}>
-      <MultiCombobox
-        label="Choose a car manufacturer"
-        items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
-        onChange={updateSelectedItems}
-        value={selectedItems}
-        placeholder="Select manufacturers"
-      />
-    </Box>
+    <>
+      <Box width={0.4} mr={4}>
+        <MultiCombobox
+          label="Choose a car manufacturer"
+          items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
+          onChange={updateSelectedCar}
+          value={selectedCar}
+          placeholder="Select manufacturers"
+        />
+      </Box>
+      <Box width={0.5}>
+        <MultiCombobox
+          label="Choose a car manufacturer"
+          labelHidden
+          placeholder="Choose a motorcycle manufacturer"
+          items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
+          onChange={updateSelectedMoto}
+          value={selectedMoto}
+        />
+      </Box>
+    </>
   );
 };
 

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -118,6 +118,7 @@ function MultiCombobox<Item>({
   disableItem = () => false,
   searchable = false,
   label = '',
+  labelHidden,
   disabled = false,
   placeholder = '',
   itemToString = item => String(item),
@@ -139,6 +140,7 @@ function MultiCombobox<Item>({
     }
   };
 
+  const itemsPt = labelHidden ? 3 : '19px';
   return (
     <Downshift<Item>
       stateReducer={stateReducer}
@@ -231,7 +233,7 @@ function MultiCombobox<Item>({
                 hidden={hidden}
               >
                 {value.length > 0 && (
-                  <Flex as="ul" wrap="wrap" pl={3} pr={10} pt="19px" pb="2px">
+                  <Flex as="ul" wrap="wrap" pl={3} pr={10} pt={itemsPt} pb="2px">
                     {value.map(selectedItem => (
                       <Tag
                         as="li"
@@ -247,9 +249,14 @@ function MultiCombobox<Item>({
                 <InputElement
                   as="input"
                   type="text"
+                  standalone={labelHidden}
                   {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
                 />
-                <InputLabel raised={!!value.length} {...getLabelProps()}>
+                <InputLabel
+                  visuallyHidden={labelHidden}
+                  raised={!!value.length}
+                  {...getLabelProps()}
+                >
                   {label}
                 </InputLabel>
               </InputControl>

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -18,6 +18,9 @@ export type MultiComboboxProps<T> = {
   /** The label associated with this dropdown form element */
   label: string;
 
+  /** Whether the label should get visually hidden */
+  labelHidden?: boolean;
+
   /** A list of entries that the dropdown will have as options */
   items: T[];
 

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -19,7 +19,7 @@ export type MultiComboboxProps<T> = {
   label: string;
 
   /** Whether the label should get visually hidden */
-  labelHidden?: boolean;
+  hideLabel?: boolean;
 
   /** A list of entries that the dropdown will have as options */
   items: T[];
@@ -118,7 +118,7 @@ function MultiCombobox<Item>({
   disableItem = () => false,
   searchable = false,
   label = '',
-  labelHidden,
+  hideLabel,
   disabled = false,
   placeholder = '',
   itemToString = item => String(item),
@@ -140,7 +140,7 @@ function MultiCombobox<Item>({
     }
   };
 
-  const itemsPt = labelHidden ? 3 : '19px';
+  const itemsPt = hideLabel ? 3 : '19px';
   return (
     <Downshift<Item>
       stateReducer={stateReducer}
@@ -249,14 +249,10 @@ function MultiCombobox<Item>({
                 <InputElement
                   as="input"
                   type="text"
-                  standalone={labelHidden}
+                  standalone={hideLabel}
                   {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
                 />
-                <InputLabel
-                  visuallyHidden={labelHidden}
-                  raised={!!value.length}
-                  {...getLabelProps()}
-                >
+                <InputLabel visuallyHidden={hideLabel} raised={!!value.length} {...getLabelProps()}>
                   {label}
                 </InputLabel>
               </InputControl>

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`renders 1`] = `
 .pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
+  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -309,6 +310,7 @@ exports[`renders with disabled option 1`] = `
 .pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
+  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -407,6 +409,7 @@ exports[`renders with icons 1`] = `
 .pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
+  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -738,6 +741,7 @@ exports[`renders with invalid option 1`] = `
 .pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
+  opacity: 1;
   color: #d64242;
   top: 0;
   left: 0;
@@ -913,6 +917,7 @@ exports[`renders with required option 1`] = `
 .pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
+  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;

--- a/src/components/utils/Input/InputElement.tsx
+++ b/src/components/utils/Input/InputElement.tsx
@@ -4,13 +4,22 @@ import { NativeAttributes } from '../../Box';
 import PseudoBox, { PseudoBoxProps } from '../../PseudoBox';
 import useTheme from '../../../utils/useTheme';
 
-export type InputElementProps = PseudoBoxProps & NativeAttributes<'input' | 'textarea'>;
+type StandaloneInputElementProps = {
+  /**
+   * Used in order to declare input element without labels
+   */
+  standalone?: boolean;
+};
+export type InputElementProps = PseudoBoxProps &
+  NativeAttributes<'input' | 'textarea'> &
+  StandaloneInputElementProps;
 
 const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, InputElementProps>(
-  function InputElement({ readOnly, ...rest }, ref) {
+  function InputElement({ readOnly, standalone, ...rest }, ref) {
     const { disabled, required, invalid } = useInputContext();
     const theme = useTheme();
-
+    const pt = standalone ? 14 : 5;
+    const pb = standalone ? 14 : 2;
     return (
       <PseudoBox
         ref={ref}
@@ -19,8 +28,8 @@ const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
         width="100%"
         height="100%"
         px={4}
-        pt={5}
-        pb={2}
+        pt={pt}
+        pb={pb}
         position="relative"
         color="gray-50"
         fontSize="medium"
@@ -30,16 +39,24 @@ const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
         _disabled={{
           opacity: 1, // we have nested disabled elements, so we don't want lower opacities to multiply
         }}
-        _placeholder={{
-          opacity: 0,
-          color: 'gray-50',
-          transition: 'opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
-        }}
-        _focus={{
-          '::placeholder': {
-            opacity: 0.4,
-          },
-        }}
+        _placeholder={
+          !standalone
+            ? {
+                opacity: 0,
+                color: 'gray-50',
+                transition: 'opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
+              }
+            : {}
+        }
+        _focus={
+          !standalone
+            ? {
+                '::placeholder': {
+                  opacity: 0.4,
+                },
+              }
+            : {}
+        }
         _autofill={{
           WebkitBoxShadow: `0 0 0 30px ${theme.colors['navyblue-600']} inset`,
           WebkitTextFillColor: theme.colors['gray-50'],

--- a/src/components/utils/Input/InputLabel.tsx
+++ b/src/components/utils/Input/InputLabel.tsx
@@ -3,11 +3,13 @@ import { useInputContext } from './InputContext';
 import Box, { NativeAttributes } from '../../Box';
 
 export type InputLabelProps = NativeAttributes<'label'> & {
+  /**  Whether the label is visually hidden. Defaults to `true` */
+  visuallyHidden?: boolean;
   /**  Whether the label should be raised up or not. Defaults to `true` */
   raised?: boolean;
 };
 
-const InputLabel: React.FC<InputLabelProps> = ({ raised = true, ...rest }) => {
+const InputLabel: React.FC<InputLabelProps> = ({ raised = true, visuallyHidden, ...rest }) => {
   const { invalid } = useInputContext();
 
   return (
@@ -15,6 +17,7 @@ const InputLabel: React.FC<InputLabelProps> = ({ raised = true, ...rest }) => {
       as="label"
       pointerEvents="none"
       fontSize="medium"
+      opacity={visuallyHidden ? 0 : 1}
       px={4}
       color={invalid ? 'red-300' : 'gray-300'}
       top={0}

--- a/src/components/utils/Menu/Menu.tsx
+++ b/src/components/utils/Menu/Menu.tsx
@@ -19,7 +19,6 @@ const Menu = React.forwardRef<HTMLElement, MenuProps>(function Menu(
     leave: { transform: 'scale(0.9, 0.9)', opacity: 0 },
     config: { duration: 150 },
   });
-
   return (
     <React.Fragment>
       {transitions.map(({ item, key, props: styles }) =>


### PR DESCRIPTION
### Background

Due to the design of the DateInput component, we have some combo boxes without any labels attached. This PR allows the creation of such visual effects.

### Changes

- Introduce a new prop called `standalone` which allows the input elements to work just with the placeholder text.

### Screenshots
![Screenshot 2020-08-26 at 10 24 01 AM](https://user-images.githubusercontent.com/1022166/91274011-bebe5500-e786-11ea-9965-ba04e4e75687.png)

