### PR TITLE
refactor: Replace `css` prop with `sx` prop

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,6 @@ module.exports = {
     ],
     '@babel/preset-react',
     '@babel/preset-typescript',
-    '@emotion/babel-preset-css-prop',
   ],
   ignore: ['**/*.d.ts'],
   plugins: ['@babel/transform-runtime'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1533,27 +1533,6 @@
         "stylis": "^4.0.1"
       }
     },
-    "@emotion/babel-plugin-jsx-pragmatic": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz",
-      "integrity": "sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
-    "@emotion/babel-preset-css-prop": {
-      "version": "11.0.0-next.10",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-11.0.0-next.10.tgz",
-      "integrity": "sha512-IQzw38r9HA6dD8zep7wsTze1TMSyBjRArx5MErYw4zW6xv0/870z7qBXKlOF7lhncb9J31/yAh+NOGEVvPOvPg==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.7.0",
-        "@babel/runtime": "^7.7.2",
-        "@emotion/babel-plugin": "^11.0.0-next.10",
-        "@emotion/babel-plugin-jsx-pragmatic": "^0.1.4"
-      }
-    },
     "@emotion/cache": {
       "version": "11.0.0-next.13",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.0.0-next.13.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@babel/preset-typescript": "^7.9.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@emotion/babel-preset-css-prop": "^11.0.0-next.10",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
     "@types/jest-axe": "^3.5.0",

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`renders 1`] = `
   cursor: default;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-top: 4px;
   padding-bottom: 4px;
   padding-left: 32px;
@@ -59,7 +59,7 @@ exports[`renders 1`] = `
   cursor: default;
 }
 
-.pounce-4 {
+.pounce-2 {
   padding-top: 4px;
   padding-bottom: 4px;
   padding-left: 32px;
@@ -91,21 +91,21 @@ exports[`renders 1`] = `
 <div>
   <div
     aria-atomic="true"
-    class="pounce-0 pounce-1"
+    class="pounce-0"
     role="status"
   >
     INFO
   </div>
   <div
     aria-atomic="true"
-    class="pounce-2 pounce-1"
+    class="pounce-1"
     role="status"
   >
     LOW
   </div>
   <div
     aria-atomic="true"
-    class="pounce-4 pounce-1"
+    class="pounce-2"
     role="status"
   >
     WHATEVER

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import css, { SystemCssProperties } from '@styled-system/css';
 import * as StyledSystem from 'styled-system';
 import { customStyleProps, shouldForwardProp, SystemProps } from './system';
 
@@ -33,6 +34,7 @@ const Box = styled('div', {
   ${StyledSystem.flexbox}
   ${StyledSystem.typography}
   ${StyledSystem.system(customStyleProps)}
+  ${props => css(props.sx as SystemCssProperties)(props)}
   ${({ truncated }) => {
     if (truncated) {
       return {

--- a/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Box allows styling on demand 1`] = `
 
 <div>
   <div
-    class="pounce-0 pounce-1"
+    class="pounce-0"
   />
 </div>
 `;
@@ -23,7 +23,7 @@ exports[`Box allows truncated values 1`] = `
 
 <div>
   <div
-    class="pounce-0 pounce-1"
+    class="pounce-0"
   />
 </div>
 `;
@@ -31,7 +31,7 @@ exports[`Box allows truncated values 1`] = `
 exports[`Box renders 1`] = `
 <div>
   <div
-    class="pounce-0 pounce-1"
+    class="pounce-0"
   />
 </div>
 `;

--- a/src/components/Box/system.ts
+++ b/src/components/Box/system.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createShouldForwardProp, props } from '@styled-system/should-forward-prop';
-import { SystemStyleObject } from '@styled-system/css';
 import * as StyledSystem from 'styled-system';
 import * as H from 'history';
 import { Theme } from '../../theme';
@@ -29,22 +28,20 @@ type RoutingProps = {
     | ((location: H.Location<H.LocationState>) => H.LocationDescriptor<H.LocationState>);
 };
 
+type RecursiveSxProp = StylingProps | { [cssSelector: string]: RecursiveSxProp | undefined };
+
 // Props related to the usage of the Emotion CSS-in-JS library
-type EmotionProps = {
+type OverridingProps = {
   /** The React Component or native HTML element to render instead.
    * @default "div"
    * @ignore
    */
   as?: React.ElementType;
-  /**
-   * Never allow an `is` prop, since users get sometimes confused between `is` and `as`
-   * @ignore
-   */
-  is?: never;
+
   /** Additional custom inline CSS to pass to the element
    * @ignore
    */
-  css?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  sx?: RecursiveSxProp;
 };
 
 // Gather the custom-named props that styled-system should accept
@@ -114,7 +111,8 @@ export const customStyleProps: Record<
 };
 
 // All of the allowed props gathered together
-export type SystemProps = ThemedStyleProps & CustomStyleProps & RoutingProps & EmotionProps;
+type StylingProps = ThemedStyleProps & CustomStyleProps;
+export type SystemProps = StylingProps & RoutingProps & OverridingProps;
 
 // extend the forwarded props by stuff that styled-system doesn't deal with
 export const shouldForwardProp = createShouldForwardProp([
@@ -125,62 +123,3 @@ export const shouldForwardProp = createShouldForwardProp([
   'transform',
   'cursor',
 ]);
-
-// Transform the custom alias to a format that styled-system CSS supports
-function transformCustomStyleAlias(
-  propName: keyof CustomStyleProps,
-  propValue: CustomStyleProps[keyof CustomStyleProps]
-) {
-  const customStylePropValue = customStyleProps[propName];
-  if (typeof customStylePropValue === 'object') {
-    return { [customStylePropValue.property as string]: propValue };
-  }
-  if (customStylePropValue === true) {
-    return {
-      [propName]: propValue,
-    };
-  }
-  return {};
-}
-
-// Transform the custom alias to a format that styled-system CSS supports
-function transformThemedAlias(
-  propName: keyof ThemedStyleProps,
-  propValue: ThemedStyleProps[keyof ThemedStyleProps]
-) {
-  return {
-    [propName]: propValue,
-  };
-}
-
-// Transform the custom alias to a format that styled-system CSS supports
-const transformAlias = (
-  propName: keyof ThemedStyleProps & keyof CustomStyleProps,
-  propValue: ThemedStyleProps[keyof ThemedStyleProps] & CustomStyleProps[keyof CustomStyleProps]
-) => {
-  if (Object.keys(customStyleProps).includes(propName)) {
-    return transformCustomStyleAlias(propName, propValue);
-  }
-  return transformThemedAlias(propName, propValue);
-};
-
-export const transformAliasProps = (props?: SystemStyleObject): SystemStyleObject => {
-  let result = {};
-  if (!props) {
-    return result;
-  }
-
-  for (const propName in props) {
-    // @ts-ignore
-    const propValue = props[propName];
-    if (typeof propValue === 'object' && !Array.isArray(propValue)) {
-      result = { ...result, [propName]: transformAliasProps(propValue) };
-    } else {
-      result = {
-        ...result,
-        ...transformAlias(propName as keyof (ThemedStyleProps | CustomStyleProps), propValue),
-      };
-    }
-  }
-  return result;
-};

--- a/src/components/Box/system.ts
+++ b/src/components/Box/system.ts
@@ -28,7 +28,7 @@ type RoutingProps = {
     | ((location: H.Location<H.LocationState>) => H.LocationDescriptor<H.LocationState>);
 };
 
-type RecursiveSxProp = StylingProps | { [cssSelector: string]: RecursiveSxProp | undefined };
+type SxProp = StylingProps | { [cssSelector: string]: SxProp | undefined };
 
 // Props related to the usage of the Emotion CSS-in-JS library
 type OverridingProps = {
@@ -41,7 +41,7 @@ type OverridingProps = {
   /** Additional custom inline CSS to pass to the element
    * @ignore
    */
-  sx?: RecursiveSxProp;
+  sx?: SxProp;
 };
 
 // Gather the custom-named props that styled-system should accept

--- a/src/components/Flex/__snapshots__/Flex.test.tsx.snap
+++ b/src/components/Flex/__snapshots__/Flex.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`Flex renders 1`] = `
 
 <div>
   <div
-    class="pounce-0 pounce-1"
+    class="pounce-0"
   />
 </div>
 `;
 
 exports[`Flex works along with Box 1`] = `
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,7 +34,7 @@ exports[`Flex works along with Box 1`] = `
   width: 200px;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-top: 32px;
   padding-bottom: 32px;
   background-color: red-300;
@@ -43,15 +43,15 @@ exports[`Flex works along with Box 1`] = `
 
 <div>
   <div
-    class="pounce-4 pounce-1"
+    class="pounce-2"
   >
     <div
-      class="pounce-0 pounce-1"
+      class="pounce-0"
     >
       Test
     </div>
     <div
-      class="pounce-2 pounce-1"
+      class="pounce-1"
     >
       Test
     </div>

--- a/src/components/Flex/utils.tsx
+++ b/src/components/Flex/utils.tsx
@@ -1,6 +1,4 @@
 import { FlexProps } from './Flex';
-import css from '@styled-system/css';
-import { transformAliasProps } from '../Box';
 
 export const getItemSpacingProps = (
   spacing: FlexProps['margin'],
@@ -12,11 +10,11 @@ export const getItemSpacingProps = (
 
   const isFlexColumn = direction && (direction as string).includes('column');
   return {
-    css: css({
-      '& > *:not(:last-child)': transformAliasProps({
+    sx: {
+      '& > *:not(:last-child)': {
         marginRight: isFlexColumn ? undefined : spacing,
         marginBottom: isFlexColumn ? spacing : undefined,
-      }),
-    }),
+      },
+    },
   };
 };

--- a/src/components/PseudoBox/PseudoBox.tsx
+++ b/src/components/PseudoBox/PseudoBox.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import css, { SystemStyleObject } from '@styled-system/css';
-import Box, { BoxProps, transformAliasProps } from '../Box';
+import Box, { BoxProps, SystemProps } from '../Box';
 
 export interface PseudoBoxProps extends BoxProps {
   /**
@@ -12,7 +11,7 @@ export interface PseudoBoxProps extends BoxProps {
    * <PseudoBox _after={{content:`""` }}/>
    * ```
    */
-  _after?: SystemStyleObject;
+  _after?: SystemProps['sx'];
   /**
    * Styles for CSS selector `&:before`
    *
@@ -22,41 +21,41 @@ export interface PseudoBoxProps extends BoxProps {
    * <PseudoBox _before={{content:`""` }}/>
    * ```
    */
-  _before?: SystemStyleObject;
+  _before?: SystemProps['sx'];
   /**
    * Styles for CSS selector `&:focus`
    *
    */
-  _focus?: SystemStyleObject;
+  _focus?: SystemProps['sx'];
   /**
    * Styles for CSS selector `&:hover`
    */
-  _hover?: SystemStyleObject;
+  _hover?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:active`
    */
-  _active?: SystemStyleObject;
+  _active?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&[aria-pressed=true]`
    * Typically used to style the current "pressed" state of toggle buttons
    */
-  _pressed?: SystemStyleObject;
+  _pressed?: SystemProps['sx'];
   /**
    * Styles to apply when the ARIA attribute `aria-selected` is `true`
    * - CSS selector `&[aria-selected=true]`
    */
-  _selected?: SystemStyleObject;
+  _selected?: SystemProps['sx'];
   /**
    * Styles to apply when a child of this element has received focus
    * - CSS Selector `&:focus-within`
    */
-  _focusWithin?: SystemStyleObject;
+  _focusWithin?: SystemProps['sx'];
 
   /**
    * Styles to apply when the ARIA attribute `aria-invalid` is `true`
    * - CSS selector `&[aria-invalid=true]`
    */
-  _invalid?: SystemStyleObject;
+  _invalid?: SystemProps['sx'];
   /**
    * Styles to apply when this element is disabled. The passed styles are applied to these CSS selectors:
    * - `&[aria-disabled=true]`
@@ -66,73 +65,73 @@ export interface PseudoBoxProps extends BoxProps {
    * - `&:focus[aria-disabled=true]`
    * - `&:hover[aria-disabled=true]`
    */
-  _disabled?: SystemStyleObject;
+  _disabled?: SystemProps['sx'];
   /**
    * Styles to apply when the ARIA attribute `aria-grabbed` is `true`
    * - CSS selector `&[aria-grabbed=true]`
    */
-  _grabbed?: SystemStyleObject;
+  _grabbed?: SystemProps['sx'];
   /**
    * Styles to apply when the ARIA attribute `aria-expanded` is `true`
    * - CSS selector `&[aria-expanded=true]`
    */
-  _expanded?: SystemStyleObject;
+  _expanded?: SystemProps['sx'];
   /**
    * Styles to apply when the ARIA attribute `aria-checked` is `true`
    * - CSS selector `&[aria-checked=true]`
    */
-  _checked?: SystemStyleObject;
+  _checked?: SystemProps['sx'];
   /**
    * Styles to apply when the ARIA attribute `aria-checked` is `mixed`
    * - CSS selector `&[aria-checked=mixed]`
    */
-  _mixed?: SystemStyleObject;
+  _mixed?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:nth-child(odd)`
    */
-  _odd?: SystemStyleObject;
+  _odd?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:nth-child(even)`
    */
-  _even?: SystemStyleObject;
+  _even?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:visited`
    */
-  _visited?: SystemStyleObject;
+  _visited?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:readonly`
    */
-  _readOnly?: SystemStyleObject;
+  _readOnly?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:first-of-type`
    */
-  _first?: SystemStyleObject;
+  _first?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:last-of-type`
    */
-  _last?: SystemStyleObject;
+  _last?: SystemProps['sx'];
   /**
    * Styles to apply when you hover on a parent that has `role=group`.
    */
-  _groupHover?: SystemStyleObject;
+  _groupHover?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:not(:first-of-type)`
    */
-  _notFirst?: SystemStyleObject;
+  _notFirst?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&:not(:last-of-type)`
    */
-  _notLast?: SystemStyleObject;
+  _notLast?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&::placeholder`.
    * Useful for inputs
    */
-  _placeholder?: SystemStyleObject;
+  _placeholder?: SystemProps['sx'];
   /**
    * Styles for CSS Selector `&::webkit-autofill`.
    * Useful for inputs
    */
-  _autofill?: SystemStyleObject;
+  _autofill?: SystemProps['sx'];
 }
 
 /**
@@ -195,38 +194,38 @@ export const PseudoBox = React.forwardRef<HTMLElement, PseudoBoxProps>(function 
   return (
     <Box
       ref={ref}
-      css={css({
-        [hover]: transformAliasProps(_hover),
-        [focus]: transformAliasProps(_focus),
-        [active]: transformAliasProps(_active),
-        [visited]: transformAliasProps(_visited),
-        [disabled]: transformAliasProps({
+      sx={{
+        [hover]: _hover,
+        [focus]: _focus,
+        [active]: _active,
+        [visited]: _visited,
+        [disabled]: {
           opacity: 0.3,
           pointerEvents: 'none',
           cursor: 'default',
           ..._disabled,
-        }),
-        [selected]: transformAliasProps(_selected),
-        [invalid]: transformAliasProps(_invalid),
-        [expanded]: transformAliasProps(_expanded),
-        [grabbed]: transformAliasProps(_grabbed),
-        [readOnly]: transformAliasProps(_readOnly),
-        [first]: transformAliasProps(_first),
-        [notFirst]: transformAliasProps(_notFirst),
-        [notLast]: transformAliasProps(_notLast),
-        [last]: transformAliasProps(_last),
-        [odd]: transformAliasProps(_odd),
-        [even]: transformAliasProps(_even),
-        [mixed]: transformAliasProps(_mixed),
-        [checked]: transformAliasProps(_checked),
-        [pressed]: transformAliasProps(_pressed),
-        [groupHover]: transformAliasProps(_groupHover),
-        [autofill]: transformAliasProps(_autofill),
-        '&::before': transformAliasProps(_before),
-        '&::after': transformAliasProps(_after),
-        '&:focus-within': transformAliasProps(_focusWithin),
+        },
+        [selected]: _selected,
+        [invalid]: _invalid,
+        [expanded]: _expanded,
+        [grabbed]: _grabbed,
+        [readOnly]: _readOnly,
+        [first]: _first,
+        [notFirst]: _notFirst,
+        [notLast]: _notLast,
+        [last]: _last,
+        [odd]: _odd,
+        [even]: _even,
+        [mixed]: _mixed,
+        [checked]: _checked,
+        [pressed]: _pressed,
+        [groupHover]: _groupHover,
+        [autofill]: _autofill,
+        '&::before': _before,
+        '&::after': _after,
+        '&:focus-within': _focusWithin,
         '&::placeholder': _placeholder ?? {},
-      })}
+      }}
       {...rest}
     />
   );

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import css, { CSSObject } from '@styled-system/css';
 import Box, { NativeAttributes } from '../Box';
 import { useTable } from './Table';
 
@@ -59,7 +58,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(function T
     return styles;
   }, [tableProps, selected]);
 
-  return <Box as="tr" role="row" ref={ref} css={css(rowStyles) as () => CSSObject} {...rest} />;
+  return <Box as="tr" role="row" ref={ref} sx={rowStyles} {...rest} />;
 });
 
 export default React.memo(TableRow);

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs renders 1`] = `
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -34,7 +34,7 @@ exports[`Tabs renders 1`] = `
   cursor: default;
 }
 
-.pounce-6 {
+.pounce-3 {
   outline: none;
 }
 
@@ -45,14 +45,14 @@ exports[`Tabs renders 1`] = `
   >
     <div
       aria-orientation="horizontal"
-      class="pounce-4 pounce-1"
+      class="pounce-2"
       data-reach-tab-list=""
       role="tablist"
     >
       <button
         aria-controls="tabs--1--panel--0"
         aria-selected="true"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         data-orientation="horizontal"
         data-reach-tab=""
         data-selected=""
@@ -65,7 +65,7 @@ exports[`Tabs renders 1`] = `
       <button
         aria-controls="tabs--1--panel--1"
         aria-selected="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         data-orientation="horizontal"
         data-reach-tab=""
         id="tabs--1--tab--1"
@@ -80,7 +80,7 @@ exports[`Tabs renders 1`] = `
     >
       <div
         aria-labelledby="tabs--1--tab--0"
-        class="pounce-6 pounce-1"
+        class="pounce-3"
         data-reach-tab-panel=""
         id="tabs--1--panel--0"
         role="tabpanel"
@@ -90,7 +90,7 @@ exports[`Tabs renders 1`] = `
       </div>
       <div
         aria-labelledby="tabs--1--tab--1"
-        class="pounce-6 pounce-1"
+        class="pounce-3"
         data-reach-tab-panel=""
         hidden=""
         id="tabs--1--panel--1"

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders 1`] = `
-.pounce-6 {
+.pounce-3 {
   background-color: transparent;
   min-height: 47px;
   border: 1px solid;
@@ -12,26 +12,26 @@ exports[`renders 1`] = `
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-6:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-6:disabled,
-.pounce-6:disabled:focus,
-.pounce-6:disabled:hover,
-.pounce-6[aria-disabled=true],
-.pounce-6[aria-disabled=true]:focus,
-.pounce-6[aria-disabled=true]:hover {
+.pounce-3:disabled,
+.pounce-3:disabled:focus,
+.pounce-3:disabled:hover,
+.pounce-3[aria-disabled=true],
+.pounce-3[aria-disabled=true]:focus,
+.pounce-3[aria-disabled=true]:hover {
   opacity: 0.3;
   pointer-events: none;
   cursor: default;
 }
 
-.pounce-6:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-6:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -39,7 +39,7 @@ exports[`renders 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +131,7 @@ exports[`renders 1`] = `
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
   color: #bdbdbd;
@@ -152,20 +152,20 @@ exports[`renders 1`] = `
 
 <div>
   <div
-    class="pounce-6 pounce-1"
+    class="pounce-3"
   >
     <div
-      class="pounce-4 pounce-1"
+      class="pounce-2"
     >
       <input
         aria-invalid="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input"
       >
         Text input
@@ -176,7 +176,7 @@ exports[`renders 1`] = `
 `;
 
 exports[`renders with disabled option 1`] = `
-.pounce-6 {
+.pounce-3 {
   background-color: transparent;
   min-height: 47px;
   border: 1px solid;
@@ -187,26 +187,26 @@ exports[`renders with disabled option 1`] = `
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-6:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-6:disabled,
-.pounce-6:disabled:focus,
-.pounce-6:disabled:hover,
-.pounce-6[aria-disabled=true],
-.pounce-6[aria-disabled=true]:focus,
-.pounce-6[aria-disabled=true]:hover {
+.pounce-3:disabled,
+.pounce-3:disabled:focus,
+.pounce-3:disabled:hover,
+.pounce-3[aria-disabled=true],
+.pounce-3[aria-disabled=true]:focus,
+.pounce-3[aria-disabled=true]:hover {
   opacity: 0.3;
   pointer-events: none;
   cursor: default;
 }
 
-.pounce-6:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-6:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -214,7 +214,7 @@ exports[`renders with disabled option 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -306,7 +306,7 @@ exports[`renders with disabled option 1`] = `
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
   color: #bdbdbd;
@@ -328,22 +328,22 @@ exports[`renders with disabled option 1`] = `
 <div>
   <div
     aria-disabled="true"
-    class="pounce-6 pounce-1"
+    class="pounce-3"
   >
     <div
-      class="pounce-4 pounce-1"
+      class="pounce-2"
     >
       <input
         aria-disabled="true"
         aria-invalid="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         disabled=""
         id="text-input-disabled"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-disabled"
       >
         Text input disabled
@@ -354,7 +354,7 @@ exports[`renders with disabled option 1`] = `
 `;
 
 exports[`renders with icons 1`] = `
-.pounce-8 {
+.pounce-4 {
   background-color: transparent;
   min-height: 47px;
   border: 1px solid;
@@ -365,26 +365,26 @@ exports[`renders with icons 1`] = `
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-8:hover {
+.pounce-4:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:disabled,
-.pounce-8:disabled:focus,
-.pounce-8:disabled:hover,
-.pounce-8[aria-disabled=true],
-.pounce-8[aria-disabled=true]:focus,
-.pounce-8[aria-disabled=true]:hover {
+.pounce-4:disabled,
+.pounce-4:disabled:focus,
+.pounce-4:disabled:hover,
+.pounce-4[aria-disabled=true],
+.pounce-4[aria-disabled=true]:focus,
+.pounce-4[aria-disabled=true]:hover {
   opacity: 0.3;
   pointer-events: none;
   cursor: default;
 }
 
-.pounce-8:focus-within {
+.pounce-4:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-4:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -392,7 +392,7 @@ exports[`renders with icons 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-6 {
+.pounce-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -404,7 +404,7 @@ exports[`renders with icons 1`] = `
   align-items: center;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
   color: #bdbdbd;
@@ -504,7 +504,7 @@ exports[`renders with icons 1`] = `
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-4 {
+.pounce-2 {
   color: currentColor;
   display: inline-block;
   vertical-align: sub;
@@ -520,26 +520,26 @@ exports[`renders with icons 1`] = `
 
 <div>
   <div
-    class="pounce-8 pounce-1"
+    class="pounce-4"
   >
     <div
-      class="pounce-6 pounce-1"
+      class="pounce-3"
     >
       <input
         aria-invalid="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input-wrench"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-wrench"
       >
         Text input wrench
       </label>
       <svg
-        class="pounce-4 pounce-1"
+        class="pounce-2"
         role="presentation"
         viewBox="0 0 24 24"
       >
@@ -550,26 +550,26 @@ exports[`renders with icons 1`] = `
     </div>
   </div>
   <div
-    class="pounce-8 pounce-1"
+    class="pounce-4"
   >
     <div
-      class="pounce-6 pounce-1"
+      class="pounce-3"
     >
       <input
         aria-invalid="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input-calendar"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-calendar"
       >
         Text input calendar
       </label>
       <svg
-        class="pounce-4 pounce-1"
+        class="pounce-2"
         role="presentation"
         viewBox="0 0 24 24"
       >
@@ -580,26 +580,26 @@ exports[`renders with icons 1`] = `
     </div>
   </div>
   <div
-    class="pounce-8 pounce-1"
+    class="pounce-4"
   >
     <div
-      class="pounce-6 pounce-1"
+      class="pounce-3"
     >
       <input
         aria-invalid="false"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input-caret"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-caret"
       >
         Text input caret
       </label>
       <svg
-        class="pounce-4 pounce-1"
+        class="pounce-2"
         role="presentation"
         viewBox="0 0 24 24"
       >
@@ -613,7 +613,7 @@ exports[`renders with icons 1`] = `
 `;
 
 exports[`renders with invalid option 1`] = `
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -705,7 +705,7 @@ exports[`renders with invalid option 1`] = `
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-6 {
+.pounce-3 {
   background-color: transparent;
   min-height: 47px;
   border: 1px solid;
@@ -716,18 +716,18 @@ exports[`renders with invalid option 1`] = `
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-6:disabled,
-.pounce-6:disabled:focus,
-.pounce-6:disabled:hover,
-.pounce-6[aria-disabled=true],
-.pounce-6[aria-disabled=true]:focus,
-.pounce-6[aria-disabled=true]:hover {
+.pounce-3:disabled,
+.pounce-3:disabled:focus,
+.pounce-3:disabled:hover,
+.pounce-3[aria-disabled=true],
+.pounce-3[aria-disabled=true]:focus,
+.pounce-3[aria-disabled=true]:hover {
   opacity: 0.3;
   pointer-events: none;
   cursor: default;
 }
 
-.pounce-6:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -735,7 +735,7 @@ exports[`renders with invalid option 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
   color: #d64242;
@@ -756,20 +756,20 @@ exports[`renders with invalid option 1`] = `
 
 <div>
   <div
-    class="pounce-6 pounce-1"
+    class="pounce-3"
   >
     <div
-      class="pounce-4 pounce-1"
+      class="pounce-2"
     >
       <input
         aria-invalid="true"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input-invalid"
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-invalid"
       >
         Text input invalid
@@ -780,7 +780,7 @@ exports[`renders with invalid option 1`] = `
 `;
 
 exports[`renders with required option 1`] = `
-.pounce-6 {
+.pounce-3 {
   background-color: transparent;
   min-height: 47px;
   border: 1px solid;
@@ -791,26 +791,26 @@ exports[`renders with required option 1`] = `
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-6:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-6:disabled,
-.pounce-6:disabled:focus,
-.pounce-6:disabled:hover,
-.pounce-6[aria-disabled=true],
-.pounce-6[aria-disabled=true]:focus,
-.pounce-6[aria-disabled=true]:hover {
+.pounce-3:disabled,
+.pounce-3:disabled:focus,
+.pounce-3:disabled:hover,
+.pounce-3[aria-disabled=true],
+.pounce-3[aria-disabled=true]:focus,
+.pounce-3[aria-disabled=true]:hover {
   opacity: 0.3;
   pointer-events: none;
   cursor: default;
 }
 
-.pounce-6:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-6:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -818,7 +818,7 @@ exports[`renders with required option 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-4 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -910,7 +910,7 @@ exports[`renders with required option 1`] = `
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.pounce-2 {
+.pounce-1 {
   padding-left: 16px;
   padding-right: 16px;
   color: #bdbdbd;
@@ -931,22 +931,22 @@ exports[`renders with required option 1`] = `
 
 <div>
   <div
-    class="pounce-6 pounce-1"
+    class="pounce-3"
   >
     <div
-      class="pounce-4 pounce-1"
+      class="pounce-2"
     >
       <input
         aria-invalid="false"
         aria-required="true"
-        class="pounce-0 pounce-1"
+        class="pounce-0"
         id="text-input-required"
         required=""
         type="text"
         value=""
       />
       <label
-        class="pounce-2 pounce-1"
+        class="pounce-1"
         for="text-input-required"
       >
         Text input required


### PR DESCRIPTION
### Background

This PR removes emotioon's babel plugin tthat allows  components to specify a `css` prop and replaces it with a similar `sx` prop. The benefits of that are:

-  `css` prop added 1 `<CSSPropInternal>` React element to the component tree of each pounce element, which has now  been  removed. This will improve performance,  since React will have to manage way fewer components

- `css` prop accepts regular CSS & needed  additional configuration to make theming  work,  while `sx` automatically accepts theme-aware props

- `sx` prop has a simple object-like API, where as `css` had a more complex one (see code below)

- Styled-system prop transformations are now handled internally in `sx`, allowing us to delete a lot of custom code

### Changes

- Remove un-needed babel preset
- Globally replaced `css` with `sx` (we  needed  a  different name for overlapping reasons & `sx` is the convention in most  design systems)
- Cleanup un-needed code
- Update all snapshots since the removal of  `css` prop leaves components with 1 emotion class  per component (previously it was 2) cc @vorillaz 

### Testing

- `npm  run test`
