### PR TITLE
Feat visually hidden

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -7,6 +7,7 @@ import {
   SystemProps,
   truncateProp,
   pseudoProps,
+  visuallyHiddenProp,
 } from '../../system';
 
 export type NativeAttributes<El extends React.ElementType> = Omit<
@@ -29,6 +30,7 @@ const Box = styled('div', {
   ${pseudoProps}
   ${sxProp}
   ${truncateProp}
+  ${visuallyHiddenProp}
 `;
 
 export default Box as React.FC<BoxProps>;

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`renders 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::-moz-placeholder {
@@ -71,6 +72,7 @@ exports[`renders 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:-ms-input-placeholder {
@@ -78,6 +80,7 @@ exports[`renders 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::placeholder {
@@ -85,6 +88,7 @@ exports[`renders 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:focus::-webkit-input-placeholder {
@@ -114,7 +118,6 @@ exports[`renders 1`] = `
   font-size: 0.875rem;
   padding-left: 16px;
   padding-right: 16px;
-  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -218,6 +221,7 @@ exports[`renders with disabled option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::-moz-placeholder {
@@ -225,6 +229,7 @@ exports[`renders with disabled option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:-ms-input-placeholder {
@@ -232,6 +237,7 @@ exports[`renders with disabled option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::placeholder {
@@ -239,6 +245,7 @@ exports[`renders with disabled option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:focus::-webkit-input-placeholder {
@@ -268,7 +275,6 @@ exports[`renders with disabled option 1`] = `
   font-size: 0.875rem;
   padding-left: 16px;
   padding-right: 16px;
-  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -356,7 +362,6 @@ exports[`renders with icons 1`] = `
   font-size: 0.875rem;
   padding-left: 16px;
   padding-right: 16px;
-  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;
@@ -396,6 +401,7 @@ exports[`renders with icons 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::-moz-placeholder {
@@ -403,6 +409,7 @@ exports[`renders with icons 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:-ms-input-placeholder {
@@ -410,6 +417,7 @@ exports[`renders with icons 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::placeholder {
@@ -417,6 +425,7 @@ exports[`renders with icons 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:focus::-webkit-input-placeholder {
@@ -586,6 +595,7 @@ exports[`renders with invalid option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::-moz-placeholder {
@@ -593,6 +603,7 @@ exports[`renders with invalid option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:-ms-input-placeholder {
@@ -600,6 +611,7 @@ exports[`renders with invalid option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::placeholder {
@@ -607,6 +619,7 @@ exports[`renders with invalid option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:focus::-webkit-input-placeholder {
@@ -655,7 +668,6 @@ exports[`renders with invalid option 1`] = `
   font-size: 0.875rem;
   padding-left: 16px;
   padding-right: 16px;
-  opacity: 1;
   color: #d64242;
   top: 0;
   left: 0;
@@ -759,6 +771,7 @@ exports[`renders with required option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::-moz-placeholder {
@@ -766,6 +779,7 @@ exports[`renders with required option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:-ms-input-placeholder {
@@ -773,6 +787,7 @@ exports[`renders with required option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0::placeholder {
@@ -780,6 +795,7 @@ exports[`renders with required option 1`] = `
   color: #f6f6f6;
   -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
 }
 
 .pounce-0:focus::-webkit-input-placeholder {
@@ -809,7 +825,6 @@ exports[`renders with required option 1`] = `
   font-size: 0.875rem;
   padding-left: 16px;
   padding-right: 16px;
-  opacity: 1;
   color: #bdbdbd;
   top: 0;
   left: 0;

--- a/src/components/utils/Input/InputElement.tsx
+++ b/src/components/utils/Input/InputElement.tsx
@@ -36,24 +36,19 @@ const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
         fontWeight="medium"
         backgroundColor="transparent"
         border={0}
-        _placeholder={
-          !standalone
-            ? {
-                opacity: 0,
-                color: 'gray-50',
-                transition: 'opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
-              }
-            : {}
-        }
-        _focus={
-          !standalone
-            ? {
-                '::placeholder': {
-                  opacity: 0.4,
-                },
-              }
-            : {}
-        }
+        _placeholder={{
+          opacity: standalone ? 1 : 0,
+          color: standalone ? 'gray-300' : 'gray-50',
+          transition: 'opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
+          fontWeight: standalone ? 'normal' : 'medium',
+        }}
+        _focus={{
+          '::placeholder': {
+            opacity: 0.4,
+            color: standalone ? 'gray-50' : undefined,
+            fontWeight: standalone ? 'medium' : undefined,
+          },
+        }}
         // @ts-ignore `WebkitBoxShadow` and `WebkitTextFillColor` are not part of the TS CSS typings
         _autofill={{
           WebkitBoxShadow: `0 0 0 30px ${theme.colors['navyblue-600']} inset`,

--- a/src/components/utils/Input/InputLabel.tsx
+++ b/src/components/utils/Input/InputLabel.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { useInputContext } from './InputContext';
-import Box, { NativeAttributes } from '../../Box';
+import Box, { BoxProps, NativeAttributes } from '../../Box';
 
-export type InputLabelProps = NativeAttributes<'label'> & {
-  /**  Whether the label is visually hidden. Defaults to `true` */
-  visuallyHidden?: boolean;
-  /**  Whether the label should be raised up or not. Defaults to `true` */
-  raised?: boolean;
-};
+export type InputLabelProps = NativeAttributes<'label'> &
+  Pick<BoxProps, 'visuallyHidden'> & {
+    /**  Whether the label should be raised up or not. Defaults to `true` */
+    raised?: boolean;
+  };
 
-const InputLabel: React.FC<InputLabelProps> = ({ raised = true, visuallyHidden, ...rest }) => {
+const InputLabel: React.FC<InputLabelProps> = ({ raised = true, ...rest }) => {
   const { invalid } = useInputContext();
 
   return (
@@ -17,7 +16,6 @@ const InputLabel: React.FC<InputLabelProps> = ({ raised = true, visuallyHidden, 
       as="label"
       pointerEvents="none"
       fontSize="medium"
-      opacity={visuallyHidden ? 0 : 1}
       px={4}
       color={invalid ? 'red-300' : 'gray-300'}
       top={0}

--- a/src/system/utility.ts
+++ b/src/system/utility.ts
@@ -12,6 +12,21 @@ export const truncateProp = ({ truncated }: any): any => {
   }
 };
 
+export const visuallyHiddenProp = ({ visuallyHidden }: any): any => {
+  if (visuallyHidden) {
+    return {
+      border: '0px',
+      height: '1px',
+      width: '1px',
+      margin: '-1px',
+      padding: '0px',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      position: 'absolute',
+    };
+  }
+};
+
 export type SxProp = StylingProps | { [cssSelector: string]: SxProp | undefined };
 export const sxProp = (props: any) => css(props.sx as SystemCssProperties)(props);
 
@@ -19,8 +34,9 @@ export type UtilityProps = {
   /** Whether should text should truncate to fill at most one line of text */
   truncated?: boolean;
 
-  /** Additional custom inline CSS to pass to the element
-   * @ignore
-   */
+  /** Additional custom inline CSS to pass to the element */
   sx?: SxProp;
+
+  /** Makes the component invisible to the eye, but still readable by screen readers */
+  visuallyHidden?: boolean;
 };


### PR DESCRIPTION
### Background

This PR adds a `visuallyHidden` prop  to the `Box` component. This hides the  `<Box>` from the UI, while still allowing screen readers to read it

### Changes

- Add `visuallyHidden` prop & remove its re-declaration in `InputLabel`
- Make standalone `InputElement` look visually like the typical `InputElement`

### Screenshots

After the changes they look more similar (notice font color & font weight) :

<img width="823" alt="Screen Shot 2020-08-26 at 1 21 59 PM" src="https://user-images.githubusercontent.com/10436045/91292903-deae4280-e79f-11ea-88a9-062b101a9ace.png">
<img width="854" alt="Screen Shot 2020-08-26 at 1 22 09 PM" src="https://user-images.githubusercontent.com/10436045/91292904-dfdf6f80-e79f-11ea-8444-29cd59906f96.png">
<img width="868" alt="Screen Shot 2020-08-26 at 1 22 14 PM" src="https://user-images.githubusercontent.com/10436045/91292906-e0780600-e79f-11ea-9aa8-72a4da8299ef.png">


### Testing

- Testing steps
