### PR TITLE
Enhance MultiCombobox UX

### DIFF
--- a/jest/utils/render.tsx
+++ b/jest/utils/render.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import ThemeProvider from '../../src/utils/ThemeProvider';
 import { render as rtlRender, RenderOptions as RtlRenderOptions } from '@testing-library/react';
 
-export const renderWithTheme = (element: React.ReactElement, options: RtlRenderOptions) => {
+export const renderWithTheme = (element: React.ReactElement, options: RtlRenderOptions = {}) => {
   return rtlRender(<ThemeProvider>{element}</ThemeProvider>, { ...options });
 };

--- a/src/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.test.tsx
@@ -1,0 +1,157 @@
+import { renderWithTheme, fireClickAndMouseEvents, fireEvent } from 'test-utils';
+import React from 'react';
+import MultiCombobox, { MultiComboboxProps } from './index';
+
+const ControlledMultiCombobox: React.FC<Partial<MultiComboboxProps<string>>> = props => {
+  const [selectedManufacturer, updateSelectedManufacturer] = React.useState<string[]>([]);
+
+  return (
+    <MultiCombobox<string>
+      label="Choose a car manufacturer"
+      items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
+      onChange={updateSelectedManufacturer}
+      value={selectedManufacturer}
+      placeholder="Select manufacturers"
+      {...props}
+    />
+  );
+};
+
+describe('MultiCombobox', () => {
+  it('renders', () => {
+    const { container } = renderWithTheme(<ControlledMultiCombobox />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('works without being searchable', async () => {
+    const { getByText, getByPlaceholderText, getAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox />
+    );
+
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+    fireClickAndMouseEvents(await getByText('Toyota'));
+    fireClickAndMouseEvents(await getByText('Ford'));
+
+    expect(getAllByRole('tag')).toHaveLength(2);
+  });
+
+  it('works while searchable', async () => {
+    const { getByText, getByPlaceholderText, getAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Toyo' } });
+    expect(getAllByRole('option')).toHaveLength(1);
+    fireClickAndMouseEvents(await getByText('Toyota'));
+
+    fireEvent.change(input, { target: { value: 'Fo' } });
+    expect(getAllByRole('option')).toHaveLength(1);
+    fireClickAndMouseEvents(await getByText('Ford'));
+
+    expect(getAllByRole('tag')).toHaveLength(2);
+  });
+
+  it("it doesn't allow custom additions by default", async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Random Value' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(queryAllByRole('tag')).toHaveLength(0);
+  });
+
+  it('works while allowing custom values', async () => {
+    const { getByPlaceholderText, getAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable allowAdditions />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Random Value 1' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    fireEvent.change(input, { target: { value: 'Random Value 2' } });
+    fireEvent.keyDown(input, { key: ',', code: 'Comma' });
+    expect(getAllByRole('tag')).toHaveLength(2);
+  });
+
+  it('correctly filters custom values when specified', async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox
+        searchable
+        allowAdditions
+        validateAddition={text => text.includes('pounce')}
+      />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Random Value' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(queryAllByRole('tag')).toHaveLength(0);
+
+    fireEvent.change(input, { target: { value: 'pounce' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    expect(queryAllByRole('tag')).toHaveLength(1);
+  });
+
+  it("doesn't tokenize value on blur when custom values are disallowed", async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers') as HTMLInputElement;
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Toyo' } });
+    fireEvent.blur(input);
+
+    expect(queryAllByRole('tag')).toHaveLength(0);
+  });
+
+  it('tokenizes value on blur when custom values are allowed', async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable allowAdditions />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturers'));
+
+    fireEvent.change(input, { target: { value: 'Random Value' } });
+    fireEvent.blur(input);
+    expect(queryAllByRole('tag')).toHaveLength(1);
+  });
+
+  it('does not auto-tokenize a single pasted value', async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable allowAdditions />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+
+    fireEvent.paste(input, { clipboardData: { getData: () => 'Random Value' } });
+    expect(queryAllByRole('tag')).toHaveLength(0);
+  });
+
+  it("auto-tokenizes a pasted value that's separated with commas or newlines", async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable allowAdditions />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Random Value 1, Random Value 2 \r\n RandomValue 3' },
+    });
+    expect(queryAllByRole('tag')).toHaveLength(3);
+  });
+});

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -221,6 +221,21 @@ function MultiCombobox<Item>({
               }
             }
           },
+          onPaste: (e: React.ClipboardEvent<HTMLInputElement>) => {
+            // Prevent the text from actually being pasted to the underlying input
+            e.preventDefault();
+            e.stopPropagation();
+
+            // Get clipboard data and split them based on newline and/or commas
+            const clipboardData = e.clipboardData.getData('Text');
+            const items = (clipboardData
+              .replace(/\r?\n/g, ',')
+              .split(',')
+              .map(str => str.trim()) as unknown) as Item[];
+
+            // extend existing values with new ones
+            onChange([...value, ...items]);
+          },
         };
 
         return (

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -211,25 +211,32 @@ function MultiCombobox<Item>({
 
             // Allow the user to add custom selections if both `searchable` and `allowAdditions`
             // have a truthy value
+            const trimmedInputValue = (inputValue || '').trim();
             if (
               (event.key === 'Enter' || event.key === ',') &&
-              searchable &&
               allowAdditions &&
-              inputValue
+              trimmedInputValue
             ) {
               event.preventDefault();
 
               // By default validateAddition always returns true. Can be overriden by the user
               // for fine-grained addition
-              if (validateAddition && validateAddition(inputValue)) {
+              if (validateAddition && validateAddition(trimmedInputValue)) {
                 selectItem((inputValue as unknown) as Item, { inputValue: '', isOpen: true });
               }
             }
           },
+          onBlur: () => {
+            const trimmedInputValue = (inputValue || '').trim();
+            if (allowAdditions && trimmedInputValue) {
+              selectItem((trimmedInputValue as unknown) as Item, { inputValue: '' });
+            }
+          },
           onPaste: (e: React.ClipboardEvent<HTMLInputElement>) => {
-            // Prevent the text from actually being pasted to the underlying input
-            e.preventDefault();
-            e.stopPropagation();
+            // prevent it when we can only select values from the dropdown
+            if (!allowAdditions) {
+              return;
+            }
 
             // Get clipboard data and split them based on newline and/or commas
             const clipboardData = e.clipboardData.getData('Text');
@@ -238,8 +245,14 @@ function MultiCombobox<Item>({
               .split(',')
               .map(str => str.trim()) as unknown) as Item[];
 
-            // extend existing values with new ones
-            onChange([...value, ...items]);
+            if (items.length > 1) {
+              // Prevent the text from actually being pasted to the underlying input
+              e.preventDefault();
+              e.stopPropagation();
+
+              // extend existing values with new ones
+              onChange([...value, ...items]);
+            }
           },
         };
 

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -211,7 +211,12 @@ function MultiCombobox<Item>({
 
             // Allow the user to add custom selections if both `searchable` and `allowAdditions`
             // have a truthy value
-            if (event.key === 'Enter' && searchable && allowAdditions && inputValue) {
+            if (
+              (event.key === 'Enter' || event.key === ',') &&
+              searchable &&
+              allowAdditions &&
+              inputValue
+            ) {
               event.preventDefault();
 
               // By default validateAddition always returns true. Can be overriden by the user

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -194,7 +194,7 @@ function MultiCombobox<Item>({
             position: !value.length ? 'static' : 'absolute',
           }),
           ...(searchable && {
-            placeholder: isOpen || (value.length && allowAdditions) ? placeholder : '',
+            placeholder,
             mt: (isOpen && value.length) || (isOpen && value.length && allowAdditions) ? -4 : 0,
             position: isOpen || (isOpen && value.length && allowAdditions) ? 'static' : 'absolute',
           }),

--- a/src/components/MultiCombobox/Tag.tsx
+++ b/src/components/MultiCombobox/Tag.tsx
@@ -14,6 +14,7 @@ export interface TagProps extends BoxProps {
 /** A chip is an entry in a combobox, but can be used anywhere */
 const Tag: React.FC<TagProps> = ({ children, onRemove, ...rest }) => (
   <Box
+    role="tag"
     bg="blue-400"
     borderRadius="pill"
     cursor="default"

--- a/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
+++ b/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiCombobox renders 1`] = `
+.pounce-4 {
+  position: relative;
+}
+
+.pounce-2 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: transparent;
+  border-radius: 4px;
+  border-color: #3e516b;
+}
+
+.pounce-2:hover {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-0 {
+  vertical-align: top;
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: static;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  opacity: 1;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  left: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(0, 14px) scale(1);
+  -moz-transform: translate(0, 14px) scale(1);
+  -ms-transform: translate(0, 14px) scale(1);
+  transform: translate(0, 14px) scale(1);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 400;
+}
+
+.pounce-3 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  color: currentColor;
+  position: absolute;
+  pointer-events: none;
+  margin-top: auto;
+  margin-bottom: auto;
+  top: 0;
+  bottom: 0;
+  right: 16px;
+}
+
+<div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-0-label"
+    class="pounce-4"
+    role="combobox"
+  >
+    <div
+      class="pounce-4"
+    >
+      <div
+        aria-disabled="false"
+        class="pounce-2"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-disabled="false"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="downshift-0-input"
+          placeholder="Select manufacturers"
+          readonly=""
+          type="text"
+          value=""
+        />
+        <label
+          class="pounce-1"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Choose a car manufacturer
+        </label>
+      </div>
+      <svg
+        class="pounce-3"
+        role="presentation"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M7 10L12 15L17 10H7Z"
+        />
+      </svg>
+    </div>
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-5"
+      id="downshift-0-menu"
+      role="listbox"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Background

One of the downsides of using MultiCombobox when expecting custom input is that people rarely realize that they need to press "Enter" to save it. In addition, people rarely realize that pressing "Enter" allows them to add more values & when using "pasted" data, that creates problems since their value is lost on blur.

This PR adds UX updates to make their life easier:

- Makes sure to automatically select custom (user entered) values on blur
- Makes sure to automatically tokenize a pasted value containing newlines or commas
- Allows `,`  to be used in the same way as `Enter`

### Changes

- Modify behavior of MultiCombobox
- Make sure to show always render placeholder text
- Add minor accessibility attributes
- Add tests to MultiCombobox

### Testing

- `npm run test`


### Context

We don't automatically convert single-pasted items into a token, since users can sometimes edit those. When pasting multiple values, users rarely want to "change" a particular one, so we automatically convert them to tokens. Agreed upon with our designer.