### PR TITLE
fix: make sure collapse animation doesn't hinder clicking

### DIFF
--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -41,9 +41,9 @@ const Collapse: React.FC<CollapseProps> = ({
   const [ref, { height }] = useMeasure({ polyfill: ResizeObserver });
 
   const transitions = useTransition(open, null, {
-    from: { height: 0, opacity: animateOpacity ? 0 : 1 },
-    enter: { height, opacity: 1 },
-    leave: { height: 0, opacity: animateOpacity ? 0 : 1 },
+    from: { height: 0, opacity: animateOpacity ? 0 : 1, pointerEvents: 'none' },
+    enter: { height, opacity: 1, pointerEvents: 'auto' },
+    leave: { height: 0, opacity: animateOpacity ? 0 : 1, pointerEvents: 'none' },
     config: { duration },
     update: { height },
   });


### PR DESCRIPTION
### Background

Currently when something is animating, the items "behind" the animation are not clickable until the animation finishes. In cases where the item gets removed from the screen, you see it disappearing but UI behind it is still not clickable until the animation finishes.

This gets fixed by  adding `pointer-events: none` to the item that's "disappearing"

### Changes

- Instantly add `pointer-events: none` to the animating item

### Testing

- Testing steps
