### PR TITLE
feat: allow custom typing extension to support custom icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,54 @@ export const myTheme = {
 };
 ```
 
+By default, pounce ships with dashboard-related icons, but you may add new ones by extending the
+`icons` keyy of the theme. For example, if you want to add a new icon named `my-icon` you would
+override the theme and pass it again to the `<ThemeProvider>` component.
+
+```js
+import { theme as defaultTheme } from 'pouncejs';
+
+const myIcons = {
+  'my-icon': {
+    path: (
+      <g id="collapse-table" stroke="none" fill="none">
+        <rect x="0" y="0" width="24" height="24" />
+      </g>
+    ),
+    viewBox: '0 0 24 24', // can be omitted if viewBox is `0 0 24 24` which is the default value
+  },
+};
+
+const theme = {
+  ...defaultTheme,
+  icons: {
+    ...defaultTheme.icons,
+    ...myIcons,
+  },
+};
+```
+
+For typescript users, the new icons won't be available by default in the typings. To make
+them available, you need to create a declaration file anywhere in your project and extend
+the `CustomIcons` interface. For example:
+
+```typescript
+// src/overrides.d.ts
+
+import 'pouncejs';
+import { myIcons } from '../myTheme'; // customIcons are declare in the snippet aoove
+
+declare module 'pouncejs' {
+  type MyIcons = typeof myIcons;
+  export interface CustomIcons extends MyIcons {}
+}
+```
+
+This way the `my-icon` value will be available in all Components that use icons.
+
 ### Performance
 
-Pounce is on its testing phase right now, which means that the performance is not optimized and the
-bundle size is not a core pillar of the development since it relies on 3rd-party packages for some
-of its modules. There is a plan to gradually migrate those away and to focus on the performance of the actual lib.
+Pounce is on its beta phase right now, which means that the performance is constantly getting tuned.
 
 If bundle size is something super crucial, you can safely import each module individually by doing `import Box from 'pouncejs/dist/esm/components/Box'` instead of the typical `import { Box } from 'pouncejs'` which will make sure to only pull what's needed for this particular component.
 

--- a/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
@@ -5533,7 +5533,7 @@ exports[`allows selecting a preset 1`] = `
                 name="test-from"
                 readonly=""
                 type="text"
-                value="09/08/2020"
+                value="09/09/2020"
               />
               <label
                 class="pounce-1"
@@ -5554,7 +5554,7 @@ exports[`allows selecting a preset 1`] = `
                 name="test-to"
                 readonly=""
                 type="text"
-                value="09/15/2020"
+                value="09/16/2020"
               />
               <label
                 class="pounce-1"
@@ -6743,7 +6743,7 @@ exports[`allows selecting a preset 1`] = `
                           <div
                             aria-busy="false"
                             aria-label="Tu Sep 08 2020"
-                            aria-selected="true"
+                            aria-selected="false"
                             class="pounce-50"
                             role="gridcell"
                           >
@@ -6761,9 +6761,9 @@ exports[`allows selecting a preset 1`] = `
                             </button>
                           </div>
                           <div
-                            aria-busy="true"
+                            aria-busy="false"
                             aria-label="We Sep 09 2020"
-                            aria-selected="false"
+                            aria-selected="true"
                             class="pounce-50"
                             role="gridcell"
                           >
@@ -6885,9 +6885,9 @@ exports[`allows selecting a preset 1`] = `
                             </button>
                           </div>
                           <div
-                            aria-busy="false"
+                            aria-busy="true"
                             aria-label="Tu Sep 15 2020"
-                            aria-selected="true"
+                            aria-selected="false"
                             class="pounce-50"
                             role="gridcell"
                           >
@@ -6907,7 +6907,7 @@ exports[`allows selecting a preset 1`] = `
                           <div
                             aria-busy="false"
                             aria-label="We Sep 16 2020"
-                            aria-selected="false"
+                            aria-selected="true"
                             class="pounce-50"
                             role="gridcell"
                           >

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Box, { BoxProps } from '../Box';
 import useTheme from '../../utils/useTheme';
-import { icons } from '../../theme';
+import { Theme } from '../../theme';
 
 export interface IconProps extends BoxProps<'svg'> {
   /** The icon that you want to show */
-  type: keyof typeof icons;
+  type: keyof Theme['icons'];
 
   /** The color of the icon */
   color?: BoxProps['color'];

--- a/src/theme/customIcons.ts
+++ b/src/theme/customIcons.ts
@@ -1,2 +1,0 @@
-// Override this in a local declaration to provide custom icon keys
-export type CustomIcons = unknown;

--- a/src/theme/customIcons.ts
+++ b/src/theme/customIcons.ts
@@ -1,0 +1,2 @@
+// Override this in a local declaration to provide custom icon keys
+export type CustomIcons = unknown;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -8,6 +8,12 @@ type radii = 'none' | 'small' | 'medium' | 'large' | 'pill' | 'circle';
 type fontFamilies = 'primary' | 'mono';
 type shadows = 'none' | 'dark50' | 'dark100' | 'dark150' | 'dark200' | 'dark250';
 
+// Override this in a local declaration to provide custom icon keys
+export type CustomIcons = unknown;
+
+// The default icons that pounce ships with
+type PounceIcons = keyof typeof icons;
+
 export interface Theme extends StyledSystemTheme {
   fontSizes: typeof typography['fontSizes'];
   lineHeights: typeof typography['lineHeights'];
@@ -18,7 +24,7 @@ export interface Theme extends StyledSystemTheme {
   colors: typeof colors;
   radii: { [key in radii]: number };
   shadows: { [key in shadows]: CSS.BoxShadowProperty };
-  icons: Record<string, { path: JSX.Element; viewBox?: string }>;
+  icons: Record<PounceIcons & CustomIcons, { path: JSX.Element; viewBox?: string }>;
 }
 
 export const theme: Theme = {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,13 +3,11 @@ import * as CSS from 'csstype';
 import colors from './colors';
 import typography from './typography';
 import icons from './icons';
+import type { CustomIcons } from './customIcons';
 
 type radii = 'none' | 'small' | 'medium' | 'large' | 'pill' | 'circle';
 type fontFamilies = 'primary' | 'mono';
 type shadows = 'none' | 'dark50' | 'dark100' | 'dark150' | 'dark200' | 'dark250';
-
-// Override this in a local declaration to provide custom icon keys
-export type CustomIcons = unknown;
 
 // The default icons that pounce ships with
 type PounceIcons = keyof typeof icons;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,14 +3,17 @@ import * as CSS from 'csstype';
 import colors from './colors';
 import typography from './typography';
 import icons from './icons';
-import type { CustomIcons } from './customIcons';
 
 type radii = 'none' | 'small' | 'medium' | 'large' | 'pill' | 'circle';
 type fontFamilies = 'primary' | 'mono';
 type shadows = 'none' | 'dark50' | 'dark100' | 'dark150' | 'dark200' | 'dark250';
 
+// Override this in a local declaration to provide custom icon keys
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CustomIcons {}
+
 // The default icons that pounce ships with
-type PounceIcons = keyof typeof icons;
+type PounceIcons = typeof icons;
 
 export interface Theme extends StyledSystemTheme {
   fontSizes: typeof typography['fontSizes'];
@@ -22,7 +25,7 @@ export interface Theme extends StyledSystemTheme {
   colors: typeof colors;
   radii: { [key in radii]: number };
   shadows: { [key in shadows]: CSS.BoxShadowProperty };
-  icons: Record<PounceIcons & CustomIcons, { path: JSX.Element; viewBox?: string }>;
+  icons: Record<keyof (PounceIcons & CustomIcons), { path: JSX.Element; viewBox?: string }>;
 }
 
 export const theme: Theme = {


### PR DESCRIPTION
### Background

Currently, pounce allows  you  to have custom icon definitions, by overriding the `icons` prop in the `theme` that gets passed  to  the `ThemeProvider`. 

So far though, you'd always be getting an invalid TS error, stating that this icon doesn't exist. To fix that, pounce now exposes a `CustomIcons` type which you can override locally in your project (using a local declaration file) in order to extend the set of known `icon`  keys that Pounce is aware of.

### Changes

- Make sure all icon keys are taken from `Theme`
- Export an empty `CustomIcons` interface in order to allow overrides
- Update docs

### Testing

- Installed it in a project and managed to get it working  on external projects by following the README instructions
