### PR TITLE
Fix global date mocks for time related specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12063,6 +12063,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mockdate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.2.tgz",
+      "integrity": "sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "jest-emotion": "^10.0.32",
     "jest-extended": "^0.11.5",
     "lint-staged": "^10.1.0",
+    "mockdate": "^3.0.2",
     "prettier": "^2.0.5",
     "react": "^16.11.0",
     "react-docgen-typescript": "^1.16.3",

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderWithTheme, fireEvent } from 'test-utils';
+import mockDate from 'mockdate';
 import dayjs from 'dayjs';
 import DateInput from './DateInput';
 
@@ -7,6 +8,14 @@ const month = 10;
 const year = 2020;
 const day = 1;
 const date = dayjs().date(day).month(month).year(year).hour(1).minute(2);
+
+beforeEach(() => {
+  mockDate.set(new Date('September 16, 2020 15:00:00'));
+});
+
+afterEach(() => {
+  mockDate.reset();
+});
 
 describe('DateInput', () => {
   it('renders', async () => {

--- a/src/components/DateRangeInput/DateRangeInput.test.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderWithTheme, fireEvent } from 'test-utils';
+import mockDate from 'mockdate';
 import dayjs from 'dayjs';
 import DateRangeInput from './DateRangeInput';
 
@@ -8,6 +9,14 @@ const year = 2020;
 const day = 1;
 const start = dayjs().date(day).month(month).year(year).hour(1).minute(2);
 const end = start.add(10, 'day');
+
+beforeEach(() => {
+  mockDate.set(new Date('September 16, 2020 15:00:00'));
+});
+
+afterEach(() => {
+  mockDate.reset();
+});
 
 const props = {
   id: 'test',


### PR DESCRIPTION
### Background
Since presets are dynamically generated using the current date snapshots are failing, thus we need to mock the global `Date` constructor. More info about the `dayjs` implementation can be found [here](https://github.com/iamkun/dayjs/issues/500)