### PR TITLE
fix: change `X` icon to `!` on the alert "error"

### DIFF
--- a/src/components/utils/ControlledAlert/useAlertStyles.tsx
+++ b/src/components/utils/ControlledAlert/useAlertStyles.tsx
@@ -21,7 +21,7 @@ const useAlertStyles = ({ variant }: UseControlledAlertStylesProps) => {
       };
     case 'error':
       return {
-        icon: 'close-circle' as const,
+        icon: 'alert-circle' as const,
         backgroundColor: 'pink-700' as const,
       };
     case 'default':


### PR DESCRIPTION
### Background

Lot of people have complained that  our "X" icon looks like a button and they attempt to click it. With this in mind, the alert error style, will use an "!" icon  that will not confused users.

### Changes

- Replace "X" icon with "!"

### Testing

- N/A
