### PR TITLE
Feat: Popover component

### DIFF
--- a/__mocks__/react-spring.ts
+++ b/__mocks__/react-spring.ts
@@ -1,0 +1,43 @@
+/**
+ * Panther is a Cloud-Native SIEM for the Modern Security Team.
+ * Copyright (C) 2020 Panther Labs Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { UseTransitionProps, TransitionKeyProps, UseTransitionResult } from 'react-spring';
+
+const realModule = jest.requireActual('react-spring');
+
+module.exports = {
+  ...realModule,
+  useTransition: <TItem, DS extends Record<string, unknown>>(
+    items: ReadonlyArray<TItem> | TItem | null | undefined,
+    keys:
+      | ((item: TItem) => TransitionKeyProps)
+      | ReadonlyArray<TransitionKeyProps>
+      | TransitionKeyProps
+      | null,
+    config: DS & UseTransitionProps<TItem, DS>
+  ): UseTransitionResult<TItem, any>[] => {
+    // Make sure to always render with the "final animation" styles (i.e. skip all the intermediate
+    // transition styles)
+    return realModule.useTransition(items, keys, config).map((transitionItem: any) => ({
+      ...transitionItem,
+      props: !items || (Array.isArray(items) && !items.length) ? config.leave : config.enter,
+    }));
+  },
+};

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -22,6 +22,8 @@ expect.addSnapshotSerializer(
   })
 );
 
+const originalError = global.console.error;
+
 // Add a dummy emotion style tag to prevent testing snapshot serializer from failing
 // https://github.com/emotion-js/emotion/issues/1960
 beforeAll(() => {
@@ -29,4 +31,20 @@ beforeAll(() => {
     'beforeend',
     `<style data-id="jest-emotion-setup" data-emotion="css"></style>`
   );
+
+  // During testing, we modify `console.error` to "hide" errors that have to do with "act" since they
+  // are noisy and force us to write complicated test assertions which the team doesn't agree with
+  global.console.error = jest.fn((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('was not wrapped in act')) {
+      return undefined;
+    }
+    return originalError(...args);
+  });
+});
+
+/**
+ * Restore `console.error` to what it originally was
+ */
+afterAll(() => {
+  (global.console.error as jest.Mock).mockRestore();
 });

--- a/jest/utils/helpers.ts
+++ b/jest/utils/helpers.ts
@@ -1,0 +1,8 @@
+/**
+ *
+ * @param ms milliseconds to wait
+ * Waits for a specific number of time
+ */
+export function waitMs(ms = 0) {
+  return new Promise(r => setTimeout(r, ms));
+}

--- a/jest/utils/index.ts
+++ b/jest/utils/index.ts
@@ -4,6 +4,7 @@ import { ThenArg } from '@reach/utils';
 export type AxeResults = ThenArg<ReturnType<typeof axe>>;
 import { fireEvent } from '@testing-library/react';
 export { renderWithTheme } from './render';
+export * from './helpers';
 export * from '@testing-library/react';
 
 export function fireClickAndMouseEvents(element: HTMLElement) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@emotion/react": "^11.0.0-next.12",
     "@emotion/styled": "^11.0.0-next.12",
     "@juggle/resize-observer": "^3.2.0",
+    "@reach/auto-id": "^0.11.2",
     "@reach/dialog": "^0.11.2",
     "@reach/menu-button": "^0.11.2",
     "@reach/popover": "^0.11.2",

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -8,7 +8,7 @@ import {
 import { useTransition, animated } from 'react-spring';
 import Box, { BoxProps } from '../Box';
 
-const AnimatedReachMenuPopover = animated(ReachMenuPopover);
+const AnimatedPopover = animated(ReachMenuPopover);
 
 export interface DropdownMenuProps {
   /** The position of the menu */
@@ -37,13 +37,7 @@ export const DropdownMenu = React.forwardRef<
       {transitions.map(
         ({ item, key, props: styles }) =>
           item && (
-            <AnimatedReachMenuPopover
-              key={key}
-              style={styles}
-              position={position}
-              ref={ref}
-              hidden={false}
-            >
+            <AnimatedPopover key={key} style={styles} position={position} ref={ref} hidden={false}>
               <Box
                 as={ReachMenuItems}
                 bg="navyblue-300"
@@ -57,7 +51,7 @@ export const DropdownMenu = React.forwardRef<
               >
                 {children}
               </Box>
-            </AnimatedReachMenuPopover>
+            </AnimatedPopover>
           )
       )}
     </React.Fragment>

--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -50,11 +50,26 @@ A popover can have a custom offset (gap) from its trigger:
 </Popover>
 ```
 
+A popover expose its internals for customized use cases:
+
+```tsx
+<Popover>
+  {({ isOpen }) => (
+    <React.Fragment>
+      <PopoverTrigger as={Button} variantColor={isOpen ? 'violet' : 'teal'}>
+        Click Me
+      </PopoverTrigger>
+      <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+    </React.Fragment>
+  )}
+</Popover>
+```
+
 A popover be visible by default:
 
 ```tsx
 <Popover isOpen>
-  <PopoverTrigger as={Button} variantColor="teal">
+  <PopoverTrigger as={Button} variantColor="red">
     Click Me
   </PopoverTrigger>
   <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>

--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -13,7 +13,9 @@ A popover can be simple:
 ```tsx
 <Popover>
   <PopoverTrigger>Click Me</PopoverTrigger>
-  <PopoverContent>Hello</PopoverContent>
+  <PopoverContent>
+    <Card p={6}>Hello</Card>
+  </PopoverContent>
 </Popover>
 ```
 
@@ -22,7 +24,9 @@ A popover can have a custom trigger:
 ```tsx
 <Popover>
   <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
-  <PopoverContent>Hello</PopoverContent>
+  <PopoverContent>
+    <Card p={6}>Hello</Card>
+  </PopoverContent>
 </Popover>
 ```
 
@@ -35,7 +39,7 @@ const Example = () => {
     <Popover>
       <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
       <PopoverContent>
-        <Box width={300}>
+        <Card p={6} width={300}>
           <Combobox
             label="Choose a car manufacturer"
             items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
@@ -43,7 +47,7 @@ const Example = () => {
             value={selectedItem}
             placeholder="Select a manufacturer"
           />
-        </Box>
+        </Card>
       </PopoverContent>
     </Popover>
   );
@@ -57,7 +61,9 @@ A popover can have an alignment:
 ```tsx
 <Popover>
   <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
-  <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+  <PopoverContent alignment="bottom-center">
+    <Card p={6}>Hello from Pounce JS</Card>
+  </PopoverContent>
 </Popover>
 ```
 
@@ -67,11 +73,13 @@ A popover can have a custom offset (gap) from its trigger:
 <Popover>
   <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
   <PopoverContent alignment="right-center" offset={[60, 0]}>
-    First Hello from Pounce JS
-    <br />
-    Second Hello from Pounce JS
-    <br />
-    Third Hello from Pounce JS
+    <Card p={6}>
+      First Hello from Pounce JS
+      <br />
+      Second Hello from Pounce JS
+      <br />
+      Third Hello from Pounce JS
+    </Card>
   </PopoverContent>
 </Popover>
 ```
@@ -86,12 +94,14 @@ A popover expose its internals for customized use cases:
         Click Me
       </PopoverTrigger>
       <PopoverContent alignment="bottom-center">
-        <Text fontSize="medium" mb={2}>
-          Hello from Pounce JS
-        </Text>
-        <Button onClick={close} size="medium">
-          Click to close
-        </Button>
+        <Card p={6}>
+          <Text fontSize="medium" mb={2}>
+            Hello from Pounce JS
+          </Text>
+          <Button onClick={close} size="medium">
+            Click to close
+          </Button>
+        </Card>
       </PopoverContent>
     </React.Fragment>
   )}
@@ -105,6 +115,8 @@ A popover be visible by default:
   <PopoverTrigger as={Button} variantColor="red">
     Click Me
   </PopoverTrigger>
-  <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+  <PopoverContent alignment="bottom-center">
+    <Card p={6}>Hello from Pounce JS</Card>
+  </PopoverContent>
 </Popover>
 ```

--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -1,0 +1,62 @@
+Popover is a non-modal dialog that floats around a trigger. It's used to display contextual information to the user, and should be paired with a clickable trigger element.
+
+A popover is comprised of 3 elements:
+
+- A `Popoup`
+- A `PopupTrigger`
+- A `PopupContent`
+
+and are all required items for the popup to appear.
+
+A popover can be simple:
+
+```tsx
+<Popover>
+  <PopoverTrigger>Click Me</PopoverTrigger>
+  <PopoverContent>Hello</PopoverContent>
+</Popover>
+```
+
+A popover can have a custom trigger:
+
+```tsx
+<Popover>
+  <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
+  <PopoverContent>Hello</PopoverContent>
+</Popover>
+```
+
+A popover can have an alignment:
+
+```tsx
+<Popover>
+  <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
+  <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+</Popover>
+```
+
+A popover can have a custom offset (gap) from its trigger:
+
+```tsx
+<Popover>
+  <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
+  <PopoverContent alignment="right-center" offset={[60, 0]}>
+    First Hello from Pounce JS
+    <br />
+    Second Hello from Pounce JS
+    <br />
+    Third Hello from Pounce JS
+  </PopoverContent>
+</Popover>
+```
+
+A popover be visible by default:
+
+```tsx
+<Popover isOpen>
+  <PopoverTrigger as={Button} variantColor="teal">
+    Click Me
+  </PopoverTrigger>
+  <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+</Popover>
+```

--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -26,6 +26,32 @@ A popover can have a custom trigger:
 </Popover>
 ```
 
+A popover can have custom content:
+
+```tsx
+const Example = () => {
+  const [selectedItem, updateSelectedItem] = React.useState(null);
+  return (
+    <Popover>
+      <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
+      <PopoverContent>
+        <Box width={300}>
+          <Combobox
+            label="Choose a car manufacturer"
+            items={['Toyota', 'Ford', 'Chevrolet', 'BMW', 'Mercedes', 'Hammer', 'Dodge', 'Audi']}
+            onChange={updateSelectedItem}
+            value={selectedItem}
+            placeholder="Select a manufacturer"
+          />
+        </Box>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+<Example />;
+```
+
 A popover can have an alignment:
 
 ```tsx
@@ -54,12 +80,19 @@ A popover expose its internals for customized use cases:
 
 ```tsx
 <Popover>
-  {({ isOpen }) => (
+  {({ isOpen, close }) => (
     <React.Fragment>
       <PopoverTrigger as={Button} variantColor={isOpen ? 'violet' : 'teal'}>
         Click Me
       </PopoverTrigger>
-      <PopoverContent alignment="bottom-center">Hello from Pounce JS</PopoverContent>
+      <PopoverContent alignment="bottom-center">
+        <Text fontSize="medium" mb={2}>
+          Hello from Pounce JS
+        </Text>
+        <Button onClick={close} size="medium">
+          Click to close
+        </Button>
+      </PopoverContent>
     </React.Fragment>
   )}
 </Popover>

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderWithTheme } from 'test-utils';
 import Popover from './Popover';
 import PopoverTrigger from './PopoverTrigger';
-import PopoverMenu from './PopoverMenu';
+import PopoverMenu from './PopoverContent';
 import Button from '../Button';
 
 describe('Popover', () => {

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { renderWithTheme } from 'test-utils';
+import Popover from './Popover';
+import PopoverTrigger from './PopoverTrigger';
+import PopoverMenu from './PopoverMenu';
+import Button from '../Button';
+
+describe('Popover', () => {
+  it('matches snapshot', () => {
+    const { container } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am The popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -1,19 +1,184 @@
 import React from 'react';
-import { renderWithTheme } from 'test-utils';
+import {
+  fireClickAndMouseEvents,
+  fireEvent,
+  renderWithTheme,
+  waitForElementToBeRemoved,
+  waitMs,
+} from 'test-utils';
 import Popover from './Popover';
 import PopoverTrigger from './PopoverTrigger';
 import PopoverMenu from './PopoverContent';
 import Button from '../Button';
+import Text from '../Text';
 
 describe('Popover', () => {
-  it('matches snapshot', () => {
+  it('matches snapshot when closed', () => {
     const { container } = renderWithTheme(
-      <Popover>
+      <Popover id="test">
         <PopoverTrigger as={Button}>Click me</PopoverTrigger>
-        <PopoverMenu>Boom! I am The popup</PopoverMenu>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
       </Popover>
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot when opened', () => {
+    const { container } = renderWithTheme(
+      <Popover isOpen id="test">
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot with offset', () => {
+    const { container } = renderWithTheme(
+      <Popover isOpen id="test">
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu offset={[10, 10]}>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot with alignment', () => {
+    const { container } = renderWithTheme(
+      <Popover isOpen id="test">
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu alignment="right-center">Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('only shows the popover trigger by default', () => {
+    const { queryByText } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(queryByText('Click me')).toBeInTheDocument();
+    expect(queryByText('Boom! I am the popup')).not.toBeInTheDocument();
+  });
+
+  it('can render as initially opened', () => {
+    const { getByText } = renderWithTheme(
+      <Popover isOpen>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    expect(getByText('Boom! I am the popup')).toBeInTheDocument();
+  });
+
+  it('toggles with trigger click', async () => {
+    const { getByText } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    fireClickAndMouseEvents(trigger);
+    await waitForElementToBeRemoved(popup);
+
+    expect(popup).not.toBeInTheDocument();
+  });
+
+  it('closes when ECS is pressed', async () => {
+    const { getByText } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    fireEvent.keyDown(popup, { key: 'Escape', code: 'Escape' });
+    await waitForElementToBeRemoved(popup);
+    expect(popup).not.toBeInTheDocument();
+  });
+
+  it('closes when a click occurs anywhere outside the popup', async () => {
+    const { getByText, container } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    // wait for React to properly assign the refs. This is not an issue in real life since a user
+    // can't do it faster than React (I tried)
+    await waitMs(10);
+    fireEvent.mouseDown(container);
+
+    await waitForElementToBeRemoved(popup);
+    expect(popup).not.toBeInTheDocument();
+  });
+
+  it('does NOT close when a click occurs inside the popup', async () => {
+    const { getByText } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    fireClickAndMouseEvents(popup);
+    await waitMs(20);
+    expect(popup).toBeInTheDocument();
+  });
+
+  it('correctly exposes its internals', async () => {
+    const { getByText } = renderWithTheme(
+      <Popover>
+        {({ close }) => (
+          <React.Fragment>
+            <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+            <PopoverMenu>
+              <Text>Boom! I am the popup</Text>
+              <Button onClick={close}>Close popup</Button>
+            </PopoverMenu>
+          </React.Fragment>
+        )}
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    fireClickAndMouseEvents(getByText('Close popup'));
+    await waitForElementToBeRemoved(popup);
+    expect(popup).not.toBeInTheDocument();
   });
 });

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import useDisclosure from '../../utils/useDisclosure';
+
+export interface PopoverProps {
+  /**
+   * Whether the popover should be initially open
+   */
+  isOpen?: boolean;
+}
+
+interface PopoverContext {
+  isOpen: boolean;
+  toggle: () => void;
+  open: () => void;
+  close: () => void;
+  triggerRef: React.RefObject<HTMLElement>;
+  popoverRef: React.RefObject<HTMLElement>;
+}
+
+// @ts-ignore
+const PopoverContext = React.createContext<PopoverContext>(undefined);
+const usePopoverContext = () => React.useContext(PopoverContext);
+
+const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) => {
+  const { isOpen, close, open, toggle } = useDisclosure({ isOpen: isInitiallyOpen });
+  const triggerRef = React.useRef(null);
+  const popoverRef = React.useRef(null);
+  const contextValue = React.useMemo(
+    () => ({
+      triggerRef,
+      popoverRef,
+      open,
+      close,
+      toggle,
+      isOpen,
+    }),
+    [triggerRef, popoverRef, close, toggle, isOpen]
+  );
+
+  return (
+    <PopoverContext.Provider value={contextValue}>
+      {typeof children === 'function' ? children(contextValue) : children}
+    </PopoverContext.Provider>
+  );
+};
+
+export { usePopoverContext };
+export default Popover;

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -6,9 +6,15 @@ export interface PopoverProps {
    * Whether the popover should be initially open
    */
   isOpen?: boolean;
+
+  /**
+   * The id of the popover. Helps setting up aria controls between popover content & trigger
+   */
+  popoverId?: string;
 }
 
 interface PopoverContext {
+  popoverId?: string;
   isOpen: boolean;
   toggle: () => void;
   open: () => void;
@@ -21,12 +27,13 @@ interface PopoverContext {
 const PopoverContext = React.createContext<PopoverContext>(undefined);
 const usePopoverContext = () => React.useContext(PopoverContext);
 
-const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) => {
+const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, popoverId, children }) => {
   const { isOpen, close, open, toggle } = useDisclosure({ isOpen: isInitiallyOpen });
   const triggerRef = React.useRef(null);
   const popoverRef = React.useRef(null);
   const contextValue = React.useMemo(
     () => ({
+      popoverId,
       triggerRef,
       popoverRef,
       open,
@@ -34,7 +41,7 @@ const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) 
       toggle,
       isOpen,
     }),
-    [triggerRef, popoverRef, close, toggle, isOpen]
+    [popoverId, triggerRef, popoverRef, close, toggle, isOpen]
   );
 
   return (

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -46,7 +46,7 @@ const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, popoverId, c
 
   return (
     <PopoverContext.Provider value={contextValue}>
-      {typeof children === 'function' ? children(contextValue) : children}
+      {typeof children === 'function' ? children({ isOpen, open, close, toggle }) : children}
     </PopoverContext.Provider>
   );
 };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -2,13 +2,6 @@ import React from 'react';
 import useDisclosure from '../../utils/useDisclosure';
 import { useId } from '@reach/auto-id';
 
-export interface PopoverProps {
-  /**
-   * Whether the popover should be initially open
-   */
-  isOpen?: boolean;
-}
-
 interface PopoverContext {
   popoverId?: string;
   isOpen: boolean;
@@ -17,6 +10,22 @@ interface PopoverContext {
   close: () => void;
   triggerRef: React.RefObject<HTMLElement>;
   popoverRef: React.RefObject<HTMLElement>;
+}
+
+export interface PopoverProps {
+  /**
+   * Whether the popover should be initially open
+   */
+  isOpen?: boolean;
+
+  /**
+   * @ignore
+   */
+  children:
+    | React.ReactNode
+    | ((
+        renderProps: Pick<PopoverContext, 'isOpen' | 'open' | 'close' | 'toggle'>
+      ) => React.ReactNode);
 }
 
 // @ts-ignore
@@ -43,6 +52,7 @@ const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) 
 
   return (
     <PopoverContext.Provider value={contextValue}>
+      {/* @ts-ignore */}
       {typeof children === 'function' ? children({ isOpen, open, close, toggle }) : children}
     </PopoverContext.Provider>
   );

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import useDisclosure from '../../utils/useDisclosure';
+import { useId } from '@reach/auto-id';
 
 export interface PopoverProps {
   /**
    * Whether the popover should be initially open
    */
   isOpen?: boolean;
-
-  /**
-   * The id of the popover. Helps setting up aria controls between popover content & trigger
-   */
-  popoverId?: string;
 }
 
 interface PopoverContext {
@@ -27,10 +23,11 @@ interface PopoverContext {
 const PopoverContext = React.createContext<PopoverContext>(undefined);
 const usePopoverContext = () => React.useContext(PopoverContext);
 
-const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, popoverId, children }) => {
+const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) => {
   const { isOpen, close, open, toggle } = useDisclosure({ isOpen: isInitiallyOpen });
   const triggerRef = React.useRef(null);
   const popoverRef = React.useRef(null);
+  const popoverId = useId();
   const contextValue = React.useMemo(
     () => ({
       popoverId,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -19,6 +19,11 @@ export interface PopoverProps {
   isOpen?: boolean;
 
   /**
+   * The id of the popover. Helps setting up aria controls between popover content & trigger
+   */
+  id?: string;
+
+  /**
    * @ignore
    */
   children:
@@ -32,11 +37,11 @@ export interface PopoverProps {
 const PopoverContext = React.createContext<PopoverContext>(undefined);
 const usePopoverContext = () => React.useContext(PopoverContext);
 
-const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, children }) => {
+const Popover: React.FC<PopoverProps> = ({ isOpen: isInitiallyOpen, id, children }) => {
   const { isOpen, close, open, toggle } = useDisclosure({ isOpen: isInitiallyOpen });
   const triggerRef = React.useRef(null);
   const popoverRef = React.useRef(null);
-  const popoverId = useId();
+  const popoverId = useId(id);
   const contextValue = React.useMemo(
     () => ({
       popoverId,

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -36,7 +36,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     forwardedRef
   ) {
     const popoverAlignment = usePopoverContentAlignment({ alignment, offset });
-    const { isOpen, triggerRef, popoverRef, close } = usePopoverContext();
+    const { popoverId, isOpen, triggerRef, popoverRef, close } = usePopoverContext();
 
     // Close on clicks outside
     React.useEffect(() => {
@@ -99,6 +99,8 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
                 style={styles}
                 targetRef={triggerRef}
                 position={popoverAlignment}
+                role="tooltip"
+                id={popoverId}
               >
                 <Card
                   p={6}

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -2,11 +2,11 @@ import React, { ReactNode } from 'react';
 import ReachUIPopover from '@reach/popover';
 import { useForkedRef } from '@reach/utils';
 import { animated, useTransition } from 'react-spring';
-import Card from '../Card';
 import { usePopoverContext } from './Popover';
 import usePopoverContentAlignment from './usePopoverContentAlignment';
 import useOutsideClick from '../../utils/useOutsideClick';
 import useEscapeKey from '../../utils/useEscapeKey';
+import Box from '../Box';
 
 const defaultOffset = [0, 12] as [number, number];
 const AnimatedPopover = animated(ReachUIPopover);
@@ -82,17 +82,9 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
                 role="tooltip"
                 id={popoverId}
               >
-                <Card
-                  p={6}
-                  ref={ref}
-                  tabIndex={0}
-                  outline="none"
-                  shadow="dark300"
-                  {...escapeKeyHandlers}
-                  {...rest}
-                >
+                <Box ref={ref} tabIndex={0} outline="none" {...escapeKeyHandlers} {...rest}>
                   {children}
-                </Card>
+                </Box>
               </AnimatedPopover>
             )
         )}

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -52,7 +52,8 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     // Close popover on clicks outside
     useOutsideClick({
       elements: [popoverRef.current, triggerRef.current],
-      callback: React.useCallback(() => isOpen && close(), [isOpen, close]),
+      callback: () => isOpen && close(),
+      disabled: !isOpen,
     });
 
     // Close on ESC key presses

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -38,10 +38,11 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     const popoverAlignment = usePopoverContentAlignment({ alignment, offset });
     const { popoverId, isOpen, triggerRef, popoverRef, close } = usePopoverContext();
 
-    // Close on clicks outside
+    // Close on clicks outside. We only want to close if a click occurred outside the popover
+    // and its trigger. We also add `capture` events to avoid some race conditions on window-attached
+    // events
     React.useEffect(() => {
       const listener = (event: MouseEvent) => {
-        // We on want to close only if a click occurred outside the popover and its trigger
         const clickTarget = event.target as Element;
         if (
           isOpen &&
@@ -70,7 +71,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       [close]
     );
 
-    // When it opens, it should immediately get focus
+    // When the popoover opens, it should immediately get focus
     React.useEffect(() => {
       window.requestAnimationFrame(() => {
         if (isOpen && popoverRef.current) {

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -1,0 +1,122 @@
+import React, { ReactNode } from 'react';
+import ReachUIPopover from '@reach/popover';
+import { useForkedRef } from '@reach/utils';
+import { animated, useTransition } from 'react-spring';
+import Card from '../Card';
+import { usePopoverContext } from './Popover';
+import usePopoverContentAlignment from './usePopoverContentAlignment';
+
+const defaultOffset = [0, 12] as [number, number];
+const AnimatedPopover = animated(ReachUIPopover);
+
+export interface PopoverContentProps {
+  /**
+   * The position to expand the popover
+   *
+   * @default left
+   */
+  alignment?: 'bottom-left' | 'bottom-center' | 'bottom-right' | 'left-center' | 'right-center';
+
+  /**
+   * The spacing between the trigger and the popover in px, for the horizontal & vertical axis
+   *
+   * @default [0, 12]
+   */
+  offset?: [number, number];
+
+  /**
+   * @ignore
+   */
+  children: ReactNode;
+}
+
+const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
+  function PopoverContent(
+    { alignment = 'bottom-left', offset = defaultOffset, children, ...rest },
+    forwardedRef
+  ) {
+    const popoverAlignment = usePopoverContentAlignment({ alignment, offset });
+    const { isOpen, triggerRef, popoverRef, close } = usePopoverContext();
+
+    // Close on clicks outside
+    React.useEffect(() => {
+      const listener = (event: MouseEvent) => {
+        // We on want to close only if a click occurred outside the popover and its trigger
+        const clickTarget = event.target as Element;
+        if (
+          isOpen &&
+          popoverRef.current &&
+          triggerRef.current &&
+          !popoverRef.current.contains(clickTarget) &&
+          !triggerRef.current.contains(clickTarget)
+        ) {
+          close();
+        }
+      };
+
+      window.addEventListener('mousedown', listener, { capture: true });
+      return () => {
+        window.removeEventListener('mousedown', listener, { capture: true });
+      };
+    }, [isOpen, close, popoverRef.current]);
+
+    // Close on ESC key presses
+    const handleKeyDown = React.useCallback(
+      ({ key }: React.KeyboardEvent) => {
+        if (key === 'Escape') {
+          close();
+        }
+      },
+      [close]
+    );
+
+    // When it opens, it should immediately get focus
+    React.useEffect(() => {
+      window.requestAnimationFrame(() => {
+        if (isOpen && popoverRef.current) {
+          popoverRef.current.focus();
+        }
+      });
+    }, [isOpen, popoverRef.current]);
+
+    // merge internal + passed prop together
+    const ref = useForkedRef(popoverRef, forwardedRef);
+
+    const transitions = useTransition(isOpen, null, {
+      from: { transform: 'translate3d(0, 10px, 0)', opacity: 0, pointerEvents: 'none' },
+      enter: { transform: 'translate3d(0, 0, 0)', opacity: 1, pointerEvents: 'auto' },
+      leave: { transform: 'translate3d(0, 10px, 0)', opacity: 0, pointerEvents: 'none' },
+      config: { duration: 250 },
+    });
+
+    return (
+      <React.Fragment>
+        {transitions.map(
+          ({ item, key, props: styles }) =>
+            item && (
+              <AnimatedPopover
+                key={key}
+                style={styles}
+                targetRef={triggerRef}
+                position={popoverAlignment}
+              >
+                <Card
+                  p={6}
+                  ref={ref}
+                  onKeyDown={handleKeyDown}
+                  tabIndex={0}
+                  outline="none"
+                  shadow="dark300"
+                  {...rest}
+                >
+                  {children}
+                </Card>
+              </AnimatedPopover>
+            )
+        )}
+      </React.Fragment>
+    );
+  }
+);
+
+export default React.memo(PopoverContent);

--- a/src/components/Popover/PopoverTrigger.tsx
+++ b/src/components/Popover/PopoverTrigger.tsx
@@ -10,7 +10,7 @@ const PopoverTrigger = forwardRefWithAs<PopoverTriggerProps, 'button'>(function 
   forwardedRef
 ) {
   // get the ref that we should store this trigger under
-  const { triggerRef, toggle } = usePopoverContext();
+  const { popoverId, triggerRef, toggle } = usePopoverContext();
 
   // merge internal + passed prop together
   const ref = useForkedRef(triggerRef, forwardedRef);
@@ -40,7 +40,15 @@ const PopoverTrigger = forwardRefWithAs<PopoverTriggerProps, 'button'>(function 
     [onKeyDown, toggle]
   );
 
-  return <Comp ref={ref} onMouseDown={handleMouseDown} onKeyDown={handleKeyDown} {...rest} />;
+  return (
+    <Comp
+      ref={ref}
+      onMouseDown={handleMouseDown}
+      onKeyDown={handleKeyDown}
+      aria-describedby={popoverId}
+      {...rest}
+    />
+  );
 });
 
 export default React.memo(PopoverTrigger) as ComponentWithAs<'button', PopoverTriggerProps>;

--- a/src/components/Popover/PopoverTrigger.tsx
+++ b/src/components/Popover/PopoverTrigger.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { ComponentWithAs, forwardRefWithAs, useForkedRef } from '@reach/utils';
+import { NativeAttributes } from '../../system';
+import { usePopoverContext } from './Popover';
+
+export type PopoverTriggerProps = NativeAttributes<'button'>;
+
+const PopoverTrigger = forwardRefWithAs<PopoverTriggerProps, 'button'>(function PopoverTrigger(
+  { as: Comp = 'button', onMouseDown, onKeyDown, ...rest },
+  forwardedRef
+) {
+  // get the ref that we should store this trigger under
+  const { triggerRef, toggle } = usePopoverContext();
+
+  // merge internal + passed prop together
+  const ref = useForkedRef(triggerRef, forwardedRef);
+
+  // Toggle Popover on click (mousedown)
+  const handleMouseDown = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      toggle();
+      if (onMouseDown) {
+        onMouseDown(event);
+      }
+    },
+    [onMouseDown, toggle]
+  );
+
+  // Toggle on Enter keypress (keydown)
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Enter') {
+        toggle();
+      }
+
+      if (onKeyDown) {
+        onKeyDown(event);
+      }
+    },
+    [onKeyDown, toggle]
+  );
+
+  return <Comp ref={ref} onMouseDown={handleMouseDown} onKeyDown={handleKeyDown} {...rest} />;
+});
+
+export default React.memo(PopoverTrigger) as ComponentWithAs<'button', PopoverTriggerProps>;

--- a/src/components/Popover/PopoverTrigger.tsx
+++ b/src/components/Popover/PopoverTrigger.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentWithAs, forwardRefWithAs, useForkedRef } from '@reach/utils';
+import { ComponentWithAs, forwardRefWithAs, useForkedRef, wrapEvent } from '@reach/utils';
 import { NativeAttributes } from '../../system';
 import { usePopoverContext } from './Popover';
 
@@ -15,36 +15,11 @@ const PopoverTrigger = forwardRefWithAs<PopoverTriggerProps, 'button'>(function 
   // merge internal + passed prop together
   const ref = useForkedRef(triggerRef, forwardedRef);
 
-  // Toggle Popover on click (mousedown)
-  const handleMouseDown = React.useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      toggle();
-      if (onMouseDown) {
-        onMouseDown(event);
-      }
-    },
-    [onMouseDown, toggle]
-  );
-
-  // Toggle on Enter keypress (keydown)
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (event.key === 'Enter') {
-        toggle();
-      }
-
-      if (onKeyDown) {
-        onKeyDown(event);
-      }
-    },
-    [onKeyDown, toggle]
-  );
-
   return (
     <Comp
       ref={ref}
-      onMouseDown={handleMouseDown}
-      onKeyDown={handleKeyDown}
+      onMouseDown={wrapEvent(onMouseDown, toggle)}
+      onKeyDown={wrapEvent(onKeyDown, ({ key }) => key === 'Enter' && toggle())}
       aria-describedby={popoverId}
       {...rest}
     />

--- a/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Popover matches snapshot when closed 1`] = `
+.pounce-0 {
+  width: auto;
+  outline: none;
+  padding-left: 20px;
+  padding-right: 20px;
+  height: 46px;
+  font-size: 0.938rem;
+  -webkit-transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  border: 1px solid;
+  border-color: #0081c5;
+  background-color: #0081c5;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.pounce-0:hover {
+  background-color: #0a8bcf;
+  border-color: #0a8bcf;
+}
+
+.pounce-0:focus {
+  background-color: #0a8bcf;
+  border-color: #55d6ff;
+}
+
+.pounce-0:active,
+.pounce-0[data-active=true] {
+  background-color: #0077bb;
+  border-color: #0077bb;
+}
+
+<div>
+  <button
+    aria-describedby="test"
+    class="pounce-0"
+    type="button"
+  >
+    Click me
+  </button>
+</div>
+`;
+
+exports[`Popover matches snapshot when opened 1`] = `
+.pounce-0 {
+  width: auto;
+  outline: none;
+  padding-left: 20px;
+  padding-right: 20px;
+  height: 46px;
+  font-size: 0.938rem;
+  -webkit-transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  border: 1px solid;
+  border-color: #0081c5;
+  background-color: #0081c5;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.pounce-0:hover {
+  background-color: #0a8bcf;
+  border-color: #0a8bcf;
+}
+
+.pounce-0:focus {
+  background-color: #0a8bcf;
+  border-color: #55d6ff;
+}
+
+.pounce-0:active,
+.pounce-0[data-active=true] {
+  background-color: #0077bb;
+  border-color: #0077bb;
+}
+
+<div>
+  <button
+    aria-describedby="test"
+    class="pounce-0"
+    type="button"
+  >
+    Click me
+  </button>
+</div>
+`;
+
+exports[`Popover matches snapshot with alignment 1`] = `
+.pounce-0 {
+  width: auto;
+  outline: none;
+  padding-left: 20px;
+  padding-right: 20px;
+  height: 46px;
+  font-size: 0.938rem;
+  -webkit-transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  border: 1px solid;
+  border-color: #0081c5;
+  background-color: #0081c5;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.pounce-0:hover {
+  background-color: #0a8bcf;
+  border-color: #0a8bcf;
+}
+
+.pounce-0:focus {
+  background-color: #0a8bcf;
+  border-color: #55d6ff;
+}
+
+.pounce-0:active,
+.pounce-0[data-active=true] {
+  background-color: #0077bb;
+  border-color: #0077bb;
+}
+
+<div>
+  <button
+    aria-describedby="test"
+    class="pounce-0"
+    type="button"
+  >
+    Click me
+  </button>
+</div>
+`;
+
+exports[`Popover matches snapshot with offset 1`] = `
+.pounce-0 {
+  width: auto;
+  outline: none;
+  padding-left: 20px;
+  padding-right: 20px;
+  height: 46px;
+  font-size: 0.938rem;
+  -webkit-transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  border-radius: 4px;
+  border: 1px solid;
+  border-color: #0081c5;
+  background-color: #0081c5;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.pounce-0:hover {
+  background-color: #0a8bcf;
+  border-color: #0a8bcf;
+}
+
+.pounce-0:focus {
+  background-color: #0a8bcf;
+  border-color: #55d6ff;
+}
+
+.pounce-0:active,
+.pounce-0[data-active=true] {
+  background-color: #0077bb;
+  border-color: #0077bb;
+}
+
+<div>
+  <button
+    aria-describedby="test"
+    class="pounce-0"
+    type="button"
+  >
+    Click me
+  </button>
+</div>
+`;

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -1,0 +1,8 @@
+export { default as Popover } from './Popover';
+export type { PopoverProps } from './Popover';
+
+export { default as PopoverContent } from './PopoverContent';
+export type { PopoverContentProps } from './PopoverContent';
+
+export { default as PopoverTrigger } from './PopoverTrigger';
+export type { PopoverTriggerProps } from './PopoverTrigger';

--- a/src/components/Popover/usePopoverContentAlignment.tsx
+++ b/src/components/Popover/usePopoverContentAlignment.tsx
@@ -1,0 +1,136 @@
+import { PopoverContentProps } from './PopoverContent';
+import { Position, getCollisions } from '@reach/popover';
+
+export const positionBottomLeft = (offset: [number, number]): Position => (
+  targetRect,
+  popoverRect
+) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionRight, directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionRight
+      ? `${targetRect.right - popoverRect.width + window.pageXOffset - offset[0]}px`
+      : `${targetRect.left + window.pageXOffset + offset[0]}px`,
+    top: directionUp
+      ? `${targetRect.top - popoverRect.height + window.pageYOffset - offset[1]}px`
+      : `${targetRect.top + targetRect.height + window.pageYOffset + offset[1]}px`,
+  };
+};
+
+export const positionBottomCenter = (offset: [number, number]): Position => (
+  targetRect,
+  popoverRect
+) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionLeft, directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionLeft
+      ? `${targetRect.left + window.pageXOffset + offset[0]}px`
+      : `${
+          targetRect.right -
+          popoverRect.width / 2 -
+          targetRect.width / 2 +
+          window.pageXOffset +
+          offset[0]
+        }px`,
+    top: directionUp
+      ? `${targetRect.top - popoverRect.height + window.pageYOffset - offset[1]}px`
+      : `${targetRect.top + targetRect.height + window.pageYOffset + offset[1]}px`,
+  };
+};
+
+export const positionBottomRight = (offset: [number, number]): Position => (
+  targetRect,
+  popoverRect
+) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionLeft, directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionLeft
+      ? `${targetRect.left + window.pageXOffset + offset[0]}px`
+      : `${targetRect.right - popoverRect.width + window.pageXOffset - offset[0]}px`,
+    top: directionUp
+      ? `${targetRect.top - popoverRect.height + window.pageYOffset - offset[1]}px`
+      : `${targetRect.top + targetRect.height + window.pageYOffset + offset[1]}px`,
+  };
+};
+
+export const positionLeftCenter = (offset: [number, number]): Position => (
+  targetRect,
+  popoverRect
+) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionRight, directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionRight
+      ? `${targetRect.right + window.pageXOffset + offset[0]}px`
+      : `${targetRect.left + window.pageXOffset - popoverRect.width - offset[0]}px`,
+    top: directionUp
+      ? `${targetRect.bottom - popoverRect.height + window.pageYOffset - offset[1]}px`
+      : `${
+          targetRect.bottom -
+          popoverRect.height / 2 -
+          targetRect.height / 2 +
+          window.pageYOffset +
+          offset[1]
+        }px`,
+  };
+};
+
+export const positionRightCenter = (offset: [number, number]): Position => (
+  targetRect,
+  popoverRect
+) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionLeft, directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionLeft
+      ? `${targetRect.left + window.pageXOffset - popoverRect.width - offset[0]}px`
+      : `${targetRect.right + window.pageXOffset + offset[0]}px`,
+    top: directionUp
+      ? `${targetRect.bottom - popoverRect.height + window.pageYOffset - offset[1]}px`
+      : `${
+          targetRect.bottom -
+          popoverRect.height / 2 -
+          targetRect.height / 2 +
+          window.pageYOffset +
+          offset[1]
+        }px`,
+  };
+};
+
+const usePopoverAlignment = ({
+  alignment,
+  offset,
+}: Required<Pick<PopoverContentProps, 'alignment' | 'offset'>>): Position => {
+  switch (alignment) {
+    case 'bottom-left':
+      return positionBottomLeft(offset);
+    case 'bottom-center':
+      return positionBottomCenter(offset);
+    case 'left-center':
+      return positionLeftCenter(offset);
+    case 'right-center':
+      return positionRightCenter(offset);
+    case 'bottom-right':
+    default:
+      return positionBottomRight(offset);
+  }
+};
+
+export default usePopoverAlignment;

--- a/src/components/Popover/usePopoverContentAlignment.tsx
+++ b/src/components/Popover/usePopoverContentAlignment.tsx
@@ -1,5 +1,26 @@
 import { PopoverContentProps } from './PopoverContent';
-import { Position, getCollisions } from '@reach/popover';
+import { Position } from '@reach/popover';
+import { PRect } from '@reach/rect';
+
+function getCollisions(targetRect: PRect, popoverRect: PRect) {
+  const collisions = {
+    top: targetRect.top - popoverRect.height < 0,
+    right: window.innerWidth < targetRect.left + popoverRect.width,
+    bottom: window.innerHeight < targetRect.bottom + popoverRect.height,
+    left: targetRect.left + targetRect.width - popoverRect.width < 0,
+  };
+  const directionRight = !collisions.right && collisions.left;
+  const directionLeft = !collisions.left && collisions.right;
+  const directionUp = !collisions.top && collisions.bottom;
+  const directionDown = !collisions.bottom && collisions.top;
+
+  return {
+    directionRight,
+    directionLeft,
+    directionUp,
+    directionDown,
+  };
+}
 
 export const positionBottomLeft = (offset: [number, number]): Position => (
   targetRect,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,7 @@ export { default as Link } from './components/Link';
 export { default as NumberInput } from './components/NumberInput';
 export { default as MultiCombobox } from './components/MultiCombobox';
 export { default as Modal } from './components/Modal';
+export * from './components/Popover';
 export { default as Radio } from './components/Radio';
 export { default as SideSheet } from './components/SideSheet';
 export { default as Snackbar } from './components/Snackbar';

--- a/src/utils/useDisclosure.tsx
+++ b/src/utils/useDisclosure.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface UseDisclosureProps {
+  isOpen?: boolean;
+}
+
+const useDisclosure = ({ isOpen: isInitiallyOpen = false }: UseDisclosureProps = {}) => {
+  const [isOpen, setIsOpen] = React.useState(isInitiallyOpen);
+
+  const open = React.useCallback(() => setIsOpen(true), [setIsOpen]);
+  const close = React.useCallback(() => setIsOpen(false), [setIsOpen]);
+  const toggle = React.useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);
+
+  return React.useMemo(
+    () => ({
+      isOpen,
+      open,
+      close,
+      toggle,
+    }),
+    [isOpen, open, close, toggle]
+  );
+};
+
+export default useDisclosure;

--- a/src/utils/useEscapeKey.tsx
+++ b/src/utils/useEscapeKey.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface UseEscapeKeyProps {
+  callback: (event: React.KeyboardEvent) => void;
+}
+
+const useEscapeKey = ({ callback }: UseEscapeKeyProps) => {
+  // Close on ESC key presses
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        callback(event);
+      }
+    },
+    [callback]
+  );
+
+  return React.useMemo(() => ({ onKeyDown: handleKeyDown }), [handleKeyDown]);
+};
+
+export default useEscapeKey;

--- a/src/utils/useOutsideClick.tsx
+++ b/src/utils/useOutsideClick.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 interface UseOutsideClickProps {
   elements: (HTMLElement | null)[];
   callback: (event: MouseEvent) => void;
+  disabled?: boolean;
 }
 
-const useOutsideClick = ({ elements, callback }: UseOutsideClickProps) => {
+const useOutsideClick = ({ elements, callback, disabled = false }: UseOutsideClickProps) => {
   // Invoke a callback on clicks outside of those elements. We also add `capture` events to avoid
   // some race conditions on window-attached events
   React.useEffect(() => {
@@ -16,11 +17,15 @@ const useOutsideClick = ({ elements, callback }: UseOutsideClickProps) => {
       }
     };
 
-    window.addEventListener('mousedown', listener, { capture: true });
+    if (!disabled) {
+      window.addEventListener('mousedown', listener, { capture: true });
+    }
     return () => {
-      window.removeEventListener('mousedown', listener, { capture: true });
+      if (!disabled) {
+        window.removeEventListener('mousedown', listener, { capture: true });
+      }
     };
-  }, [callback, ...elements]);
+  }, [callback, disabled, ...elements]);
 };
 
 export default useOutsideClick;

--- a/src/utils/useOutsideClick.tsx
+++ b/src/utils/useOutsideClick.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface UseOutsideClickProps {
+  elements: (HTMLElement | null)[];
+  callback: (event: MouseEvent) => void;
+}
+
+const useOutsideClick = ({ elements, callback }: UseOutsideClickProps) => {
+  // Invoke a callback on clicks outside of those elements. We also add `capture` events to avoid
+  // some race conditions on window-attached events
+  React.useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      const isOutsideClick = elements.every(el => el && !el.contains(event.target as Element));
+      if (isOutsideClick) {
+        callback(event);
+      }
+    };
+
+    window.addEventListener('mousedown', listener, { capture: true });
+    return () => {
+      window.removeEventListener('mousedown', listener, { capture: true });
+    };
+  }, [callback, ...elements]);
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
### Background

This PR introduced a `Popover` component, which is part of a compound component family, comprising of:

- `Popover`: a wrapper (like `Dropdown`) that manages the state and decides what's shown and what's not
- `PopoverTrigger`: a trigger element (like `DropdownButton`) which acts as the trigger of the popover
 `PopoverContent`: the actual popover that gets rendered

### Features

- Allow `Popover` to render as initially visible
- Allow `PopoverMenu` to have custom positioning
- Allow `offset` distance between the trigger and the popover
- Toggle popover on trigger click
- Toggle popover on trigger <Enter> keypress
- Close popover on click outside
- Close popover on ECS key press
- Move focus to popover as soon as its opened
- Accept render props components, exposing its internal state

### Changes

- Adds Popover compound component family

### Testing

- Snapshots
- TBA
