### PR TITLE
fix: stop loading the entire lodash library for a single method

### DIFF
--- a/src/components/DateInput/Month.tsx
+++ b/src/components/DateInput/Month.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 import Flex from '../Flex';
 import Box from '../Box';
 import Day from './Day';


### PR DESCRIPTION
### Background

Currently we bundle all of lodash, even though we use a single method of it. This increases our bundle size by at least 50KB!

### Changes

- Change `import { X } from 'lodash'` to `import X from 'lodash/X'`

### Testing

- `npm run test`
