### PR TITLE
Refactor internal utility hooks

### DIFF
--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -48,11 +48,11 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
           popoverRef.current.focus();
         }
       });
-    }, [isOpen, popoverRef.current]);
+    }, [isOpen, popoverRef]);
 
     // Close popover on clicks outside
     useOutsideClick({
-      elements: [popoverRef.current, triggerRef.current],
+      refs: [popoverRef, triggerRef],
       callback: () => isOpen && close(),
       disabled: !isOpen,
     });

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -58,7 +58,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     });
 
     // Close on ESC key presses
-    const escapeKeyHandlers = useEscapeKey({ callback: close });
+    useEscapeKey({ ref: popoverRef, callback: close, disabled: !isOpen });
 
     // merge internal + passed prop together
     const ref = useForkedRef(popoverRef, forwardedRef);
@@ -83,7 +83,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
                 role="tooltip"
                 id={popoverId}
               >
-                <Box ref={ref} tabIndex={0} outline="none" {...escapeKeyHandlers} {...rest}>
+                <Box ref={ref} tabIndex={0} outline="none" {...rest}>
                   {children}
                 </Box>
               </AnimatedPopover>

--- a/src/utils/useEscapeKey.tsx
+++ b/src/utils/useEscapeKey.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
 
 interface UseEscapeKeyProps {
-  callback: (event: React.KeyboardEvent) => void;
+  ref: React.RefObject<HTMLElement> | React.MutableRefObject<HTMLElement>;
+  callback: (event: KeyboardEvent) => void;
+  disabled?: boolean;
 }
 
-const useEscapeKey = ({ callback }: UseEscapeKeyProps) => {
-  // Close on ESC key presses
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key === 'Escape') {
+const useEscapeKey = ({ ref, callback, disabled = false }: UseEscapeKeyProps) => {
+  const listener = React.useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && ref.current?.contains(event.target as HTMLElement)) {
         callback(event);
       }
     },
-    [callback]
+    [callback, ref]
   );
 
-  return React.useMemo(() => ({ onKeyDown: handleKeyDown }), [handleKeyDown]);
+  React.useEffect(() => {
+    if (!disabled) {
+      window.addEventListener('keydown', listener);
+    }
+    return () => {
+      if (!disabled) {
+        window.removeEventListener('keydown', listener);
+      }
+    };
+  }, [disabled, listener]);
 };
 
 export default useEscapeKey;

--- a/src/utils/useOutsideClick.tsx
+++ b/src/utils/useOutsideClick.tsx
@@ -9,16 +9,20 @@ interface UseOutsideClickProps {
 const useOutsideClick = ({ refs, callback, disabled = false }: UseOutsideClickProps) => {
   // Invoke a callback on clicks outside of those elements. We also add `capture` events to avoid
   // some race conditions on window-attached events
-  React.useEffect(() => {
-    const listener = (event: MouseEvent) => {
+
+  const listener = React.useCallback(
+    (event: MouseEvent) => {
       const isOutsideClick = refs.every(
         ref => ref.current && !ref.current.contains(event.target as Element)
       );
       if (isOutsideClick) {
         callback(event);
       }
-    };
+    },
+    [callback, ...refs]
+  );
 
+  React.useEffect(() => {
     if (!disabled) {
       window.addEventListener('mousedown', listener, { capture: true });
     }
@@ -27,7 +31,7 @@ const useOutsideClick = ({ refs, callback, disabled = false }: UseOutsideClickPr
         window.removeEventListener('mousedown', listener, { capture: true });
       }
     };
-  }, [callback, disabled, ...refs]);
+  }, [listener, disabled]);
 };
 
 export default useOutsideClick;

--- a/src/utils/useOutsideClick.tsx
+++ b/src/utils/useOutsideClick.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 
 interface UseOutsideClickProps {
-  elements: (HTMLElement | null)[];
+  refs: (React.RefObject<HTMLElement> | React.MutableRefObject<HTMLElement>)[];
   callback: (event: MouseEvent) => void;
   disabled?: boolean;
 }
 
-const useOutsideClick = ({ elements, callback, disabled = false }: UseOutsideClickProps) => {
+const useOutsideClick = ({ refs, callback, disabled = false }: UseOutsideClickProps) => {
   // Invoke a callback on clicks outside of those elements. We also add `capture` events to avoid
   // some race conditions on window-attached events
   React.useEffect(() => {
     const listener = (event: MouseEvent) => {
-      const isOutsideClick = elements.every(el => el && !el.contains(event.target as Element));
+      const isOutsideClick = refs.every(
+        ref => ref.current && !ref.current.contains(event.target as Element)
+      );
       if (isOutsideClick) {
         callback(event);
       }
@@ -25,7 +27,7 @@ const useOutsideClick = ({ elements, callback, disabled = false }: UseOutsideCli
         window.removeEventListener('mousedown', listener, { capture: true });
       }
     };
-  }, [callback, disabled, ...elements]);
+  }, [callback, disabled, ...refs]);
 };
 
 export default useOutsideClick;


### PR DESCRIPTION
### Background

This PR is a pre-cursor to upcoming changes related to `DateInput` and `DateRangeInput`. It changes the way we define our utility hooks `useOutsideClick` and `useEscapeClick` in order to align more with the way we do stuff in the `DateRangeInput` component.

This PR shouldn't add any change to Pounce's exports, but simply re-write its internals

### Changes

- Change `useOutsideClick` to accept `refs` instead of `HTMLElements` due to the way `React.Ref` lifecycle works in React, which caused bugs in some extreme use cases
- Change `useEscapeClick` to accept a `ref` instead of exposing 2 handlers to be added to a JSX element. This aligns with the way `useOutsideClick` works

### Testing

- `npm run test`
- The internal modules don't have tests of their own since their functionality is always tested via the testing of the actual exports
