### PR TITLE
Aggelos daterange click outside

### DIFF
--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderWithTheme, fireEvent } from 'test-utils';
+import { renderWithTheme, fireEvent, waitForElementToBeRemoved } from 'test-utils';
 import mockDate from 'mockdate';
 import dayjs from 'dayjs';
 import DateInput from './DateInput';
@@ -128,5 +128,44 @@ describe('DateInput', () => {
     await fireEvent.click(submitBtn);
 
     expect(mock).toHaveBeenCalled();
+  });
+
+  it('closes on an outside click', async () => {
+    const mock = jest.fn();
+    const { container, findByLabelText, findByText } = await renderWithTheme(
+      <DateInput label="test" value={new Date()} onChange={mock} />
+    );
+
+    // Open the date input components
+    fireEvent.click(await findByLabelText('test'));
+
+    const dateHeader = await findByText('September 2020');
+    expect(dateHeader).toBeInTheDocument();
+
+    fireEvent.mouseDown(container);
+
+    await waitForElementToBeRemoved(dateHeader);
+    expect(dateHeader).not.toBeInTheDocument();
+  });
+
+  it('toggles when the calendar icon is clicked', async () => {
+    const mock = jest.fn();
+    const { container, findByText } = await renderWithTheme(
+      <DateInput label="test" value={new Date()} onChange={mock} />
+    );
+    const calendarIconButton = container.querySelector(
+      '[aria-label="Toggle picker"]'
+    ) as HTMLButtonElement;
+
+    // Open the date input components
+    fireEvent.click(calendarIconButton);
+
+    const dateHeader = await findByText('September 2020');
+    expect(dateHeader).toBeInTheDocument();
+
+    fireEvent.click(calendarIconButton);
+
+    await waitForElementToBeRemoved(dateHeader);
+    expect(dateHeader).not.toBeInTheDocument();
   });
 });

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -9,6 +9,9 @@ import DateWrapper from './DateWrapper';
 import TextInput, { TextInputProps } from '../TextInput';
 import TimePicker from './TimePicker';
 import { noop } from '../../utils/helpers';
+import useDisclosure from '../../utils/useDisclosure';
+import useEscapeKey from '../../utils/useEscapeKey';
+import useOutsideClick from '../../utils/useOutsideClick';
 
 export interface DateInputProps {
   /**
@@ -65,12 +68,13 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
   ...rest
 }) => {
   const ref = React.useRef(null);
+  const targetRef = React.useRef(null);
   const dateFormatted = value ? dayjs(value) : dayjs();
   const [currentMonth, setCurrentMonth] = useState(dateFormatted);
   const [currentDate, setCurrentDate] = useState(value);
   const [prevDate, setPrevDate] = useState(value);
 
-  const [open, setOpen] = useState(false);
+  const { isOpen, open, close, toggle } = useDisclosure();
 
   const onNextMonth = useCallback(
     e => {
@@ -80,6 +84,7 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
     },
     [currentMonth, setCurrentMonth]
   );
+
   const onPreviousMonth = useCallback(
     e => {
       e.preventDefault();
@@ -91,25 +96,17 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
 
   const onCancel = useCallback(() => {
     setCurrentDate(prevDate);
-    setOpen(false);
-  }, [setOpen, prevDate, setCurrentDate]);
+    close();
+  }, [close, prevDate, setCurrentDate]);
 
   const onApply = useCallback(
     e => {
       e.preventDefault();
       setPrevDate(currentDate);
       onChange(currentDate);
-      setOpen(false);
+      close();
     },
-    [setOpen, setPrevDate, onChange, currentDate]
-  );
-
-  const onExpand = useCallback(
-    e => {
-      e.preventDefault();
-      setOpen(true);
-    },
-    [setOpen]
+    [close, setPrevDate, onChange, currentDate]
   );
 
   const onDaySelect = useCallback(
@@ -125,21 +122,39 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
     setCurrentDate(timeUpdated.toDate());
   }, []);
 
+  // Close on ESC key presses
+  useEscapeKey({ ref, callback: onCancel, disabled: !isOpen });
+
+  // Close popover on clicks outside
+  useOutsideClick({
+    refs: [ref, targetRef],
+    callback: onCancel,
+    disabled: !isOpen,
+  });
+
   return (
-    <Box position="relative" ref={ref}>
-      <Box onClick={onExpand} cursor="pointer">
-        <TextInput
-          {...rest}
-          variant={variant}
-          value={currentDate ? dayjs(currentDate).format(format) : ''}
-          autoComplete="off"
+    <Box position="relative" ref={targetRef}>
+      <TextInput
+        {...rest}
+        variant={variant}
+        value={currentDate ? dayjs(currentDate).format(format) : ''}
+        onClick={open}
+        autoComplete="off"
+        aria-autocomplete="none"
+        tabIndex={-1}
+        readOnly
+      />
+
+      <Box position="absolute" top={2} right={3} zIndex={2}>
+        <IconButton
+          variant="unstyled"
+          aria-label="Toggle picker"
+          size="medium"
           icon="calendar"
-          aria-autocomplete="none"
-          tabIndex={-1}
-          readOnly
+          onClick={toggle}
         />
       </Box>
-      <DateWrapper targetRef={ref} alignment={alignment} isExpanded={open}>
+      <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={isOpen}>
         <Flex align="center" justify="space-between" p={4}>
           <IconButton
             onClick={onPreviousMonth}

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -74,7 +74,7 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
   const [currentDate, setCurrentDate] = useState(value);
   const [prevDate, setPrevDate] = useState(value);
 
-  const { isOpen, open, close, toggle } = useDisclosure();
+  const { isOpen, open, close } = useDisclosure();
 
   const onNextMonth = useCallback(
     e => {
@@ -151,7 +151,7 @@ const DateInput: React.FC<DateInputProps & Omit<TextInputProps, 'value' | 'onCha
           aria-label="Toggle picker"
           size="medium"
           icon="calendar"
-          onClick={toggle}
+          onClick={isOpen ? onCancel : open}
         />
       </Box>
       <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={isOpen}>

--- a/src/components/DateInput/DateWrapper.tsx
+++ b/src/components/DateInput/DateWrapper.tsx
@@ -12,41 +12,39 @@ interface DateWrapperProps {
 
 const AnimatedPopover = animated(Popover);
 
-const DateWrapper: React.FC<DateWrapperProps> = ({
-  children,
-  isExpanded,
-  targetRef,
-  alignment = 'left',
-}) => {
-  const position = useDropdownAlignment({ alignment });
-  const transitions = useTransition(isExpanded, null, {
-    from: { transform: 'translate3d(0, -10px, 0)', opacity: 0, pointerEvents: 'none' },
-    enter: { transform: 'translate3d(0, 0, 0)', opacity: 1, pointerEvents: 'auto' },
-    leave: { transform: 'translate3d(0, -10px, 0)', opacity: 0, pointerEvents: 'none' },
-    config: { duration: 250 },
-  });
-  return (
-    <>
-      {transitions.map(
-        ({ item, key, props: styles }) =>
-          item && (
-            <AnimatedPopover targetRef={targetRef} position={position} key={key} style={styles}>
-              <Card
-                position="absolute"
-                boxShadow="dark300"
-                // ugly hack to prevent overlapping popovers due to
-                right={alignment === 'right' && '100%'}
-                mt={4}
-                top={0}
-                zIndex={10}
-              >
-                {children}
-              </Card>
-            </AnimatedPopover>
-          )
-      )}
-    </>
-  );
-};
+const DateWrapper = React.forwardRef<HTMLElement, React.PropsWithChildren<DateWrapperProps>>(
+  function DateWrapper({ children, isExpanded, targetRef, alignment = 'left' }, ref) {
+    const position = useDropdownAlignment({ alignment });
+    const transitions = useTransition(isExpanded, null, {
+      from: { transform: 'translate3d(0, -10px, 0)', opacity: 0, pointerEvents: 'none' },
+      enter: { transform: 'translate3d(0, 0, 0)', opacity: 1, pointerEvents: 'auto' },
+      leave: { transform: 'translate3d(0, -10px, 0)', opacity: 0, pointerEvents: 'none' },
+      config: { duration: 250 },
+    });
+    return (
+      <>
+        {transitions.map(
+          ({ item, key, props: styles }) =>
+            item && (
+              <AnimatedPopover targetRef={targetRef} position={position} key={key} style={styles}>
+                <Card
+                  ref={ref}
+                  position="absolute"
+                  boxShadow="dark300"
+                  // ugly hack to prevent overlapping popovers due to
+                  right={alignment === 'right' && '100%'}
+                  mt={4}
+                  top={0}
+                  zIndex={10}
+                >
+                  {children}
+                </Card>
+              </AnimatedPopover>
+            )
+        )}
+      </>
+    );
+  }
+);
 
 export default DateWrapper;

--- a/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -1,15 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DateInput allows passing a custom format 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -20,15 +16,15 @@ exports[`DateInput allows passing a custom format 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -36,7 +32,7 @@ exports[`DateInput allows passing a custom format 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -53,7 +49,6 @@ exports[`DateInput allows passing a custom format 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -140,7 +135,33 @@ exports[`DateInput allows passing a custom format 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -149,68 +170,68 @@ exports[`DateInput allows passing a custom format 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11 Nov 2020 1 Su"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11 Nov 2020 1 Su"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput allows selecting a date with time options 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -221,15 +242,15 @@ exports[`DateInput allows selecting a date with time options 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -237,7 +258,7 @@ exports[`DateInput allows selecting a date with time options 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -254,7 +275,6 @@ exports[`DateInput allows selecting a date with time options 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -341,7 +361,33 @@ exports[`DateInput allows selecting a date with time options 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -350,68 +396,68 @@ exports[`DateInput allows selecting a date with time options 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -422,15 +468,15 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -438,7 +484,7 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -455,7 +501,6 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -542,7 +587,33 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -551,68 +622,68 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput can be solid 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -629,7 +700,6 @@ exports[`DateInput can be solid 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -716,7 +786,33 @@ exports[`DateInput can be solid 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -725,12 +821,9 @@ exports[`DateInput can be solid 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -741,15 +834,15 @@ exports[`DateInput can be solid 1`] = `
   border-color: #23344e;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -759,61 +852,64 @@ exports[`DateInput can be solid 1`] = `
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput opens the month picker 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -824,15 +920,15 @@ exports[`DateInput opens the month picker 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -840,7 +936,7 @@ exports[`DateInput opens the month picker 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -857,7 +953,6 @@ exports[`DateInput opens the month picker 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -944,7 +1039,33 @@ exports[`DateInput opens the month picker 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -953,68 +1074,68 @@ exports[`DateInput opens the month picker 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput opens the month picker with alignment 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1025,15 +1146,15 @@ exports[`DateInput opens the month picker with alignment 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1041,7 +1162,7 @@ exports[`DateInput opens the month picker with alignment 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1058,7 +1179,6 @@ exports[`DateInput opens the month picker with alignment 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -1145,7 +1265,33 @@ exports[`DateInput opens the month picker with alignment 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1154,68 +1300,68 @@ exports[`DateInput opens the month picker with alignment 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`DateInput renders 1`] = `
-.pounce-6 {
+.pounce-7 {
   position: relative;
 }
 
-.pounce-5 {
-  cursor: pointer;
-}
-
-.pounce-4 {
+.pounce-3 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1226,15 +1372,15 @@ exports[`DateInput renders 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-4:hover {
+.pounce-3:hover {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within {
+.pounce-3:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-4:focus-within label {
+.pounce-3:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1242,7 +1388,7 @@ exports[`DateInput renders 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-3 {
+.pounce-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1259,7 +1405,6 @@ exports[`DateInput renders 1`] = `
   width: 100%;
   height: 100%;
   padding-left: 16px;
-  padding-right: 40px;
   padding-top: 20px;
   padding-bottom: 8px;
   position: relative;
@@ -1346,7 +1491,33 @@ exports[`DateInput renders 1`] = `
   font-weight: 500;
 }
 
-.pounce-2 {
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1355,53 +1526,57 @@ exports[`DateInput renders 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  z-index: 1;
-  position: absolute;
-  right: 16px;
 }
 
 <div>
   <div
-    class="pounce-6"
+    class="pounce-7"
   >
     <div
-      class="pounce-5"
+      class="pounce-3"
     >
       <div
-        class="pounce-4"
+        class="pounce-2"
       >
-        <div
-          class="pounce-3"
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
         >
-          <input
-            aria-autocomplete="none"
-            aria-invalid="false"
-            aria-readonly="true"
-            autocomplete="off"
-            class="pounce-0"
-            id="test"
-            readonly=""
-            tabindex="-1"
-            type="text"
-            value="11/01/2020"
-          />
-          <label
-            class="pounce-1"
-            for="test"
-          >
-            test
-          </label>
-          <svg
-            class="pounce-2"
-            role="presentation"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-            />
-          </svg>
-        </div>
+          test
+        </label>
       </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/src/components/DateRangeInput/DateRangeInput.test.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderWithTheme, fireEvent } from 'test-utils';
 import mockDate from 'mockdate';
 import dayjs from 'dayjs';
+import { waitForElementToBeRemoved } from 'test-utils';
 import DateRangeInput from './DateRangeInput';
 
 const month = 10;
@@ -274,4 +275,23 @@ it('allows selecting a date range', async () => {
 
   expect(mock).toHaveBeenCalled();
   expect(container).toMatchSnapshot();
+});
+
+it('closes on an outside click', async () => {
+  const mock = jest.fn();
+  const { container, findByLabelText, findByText } = await renderWithTheme(
+    <DateRangeInput {...props} onChange={mock} />
+  );
+  const input = await findByLabelText('From date');
+
+  // Open the date input components
+  fireEvent.click(input);
+
+  const dateHeader = await findByText('November 2020');
+  expect(dateHeader).toBeInTheDocument();
+
+  fireEvent.mouseDown(container);
+
+  await waitForElementToBeRemoved(dateHeader);
+  expect(dateHeader).not.toBeInTheDocument();
 });

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -115,7 +115,7 @@ const DateRangeInput: React.FC<
   const [currentMonth, setCurrentMonth] = useState(datesFormatted[0]);
   const [prevDateRange, setPrevDateRange] = useState(value);
 
-  const { isOpen, open, close, toggle } = useDisclosure();
+  const { isOpen, open, close } = useDisclosure();
   const ref = React.useRef(null);
   const targetRef = React.useRef(null);
 
@@ -255,7 +255,7 @@ const DateRangeInput: React.FC<
           aria-label="Toggle picker"
           size="medium"
           icon="calendar"
-          onClick={toggle}
+          onClick={isOpen ? onCancel : open}
         />
       </Box>
       <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={isOpen}>

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { IconButton } from '../../index';
+import IconButton from '../IconButton';
 import Box from '../Box';
 import Presets from './Presets';
 import Flex from '../Flex';
@@ -13,6 +13,7 @@ import { TextInputProps } from '../TextInput';
 import { noop, getDates } from '../../utils/helpers';
 import useEscapeKey from '../../utils/useEscapeKey';
 import useOutsideClick from '../../utils/useOutsideClick';
+import useDisclosure from '../../utils/useDisclosure';
 
 export interface DateRangeInputProps {
   /**
@@ -114,23 +115,23 @@ const DateRangeInput: React.FC<
   const [currentMonth, setCurrentMonth] = useState(datesFormatted[0]);
   const [prevDateRange, setPrevDateRange] = useState(value);
 
-  const [open, setOpen] = useState(false);
+  const { isOpen, open, close, toggle } = useDisclosure();
   const ref = React.useRef(null);
   const targetRef = React.useRef(null);
 
   const onCancel = useCallback(() => {
     setCurrentRange(prevDateRange);
-    setOpen(false);
-  }, [setOpen, prevDateRange, setCurrentRange]);
+    close();
+  }, [close, prevDateRange, setCurrentRange]);
 
   const onApply = useCallback(
     e => {
       e.preventDefault();
       setPrevDateRange(currentDateRange);
       onChange(currentDateRange);
-      setOpen(false);
+      close;
     },
-    [setOpen, setPrevDateRange, onChange, currentDateRange]
+    [close, setPrevDateRange, onChange, currentDateRange]
   );
 
   const onNextMonth = useCallback(
@@ -169,13 +170,6 @@ const DateRangeInput: React.FC<
       return values[key] ? dayjs(values[key]).format(format) : '';
     },
     [format]
-  );
-  const onExpand = useCallback(
-    e => {
-      e.preventDefault();
-      setOpen(true);
-    },
-    [setOpen]
   );
 
   const onDaySelect = useCallback(
@@ -239,7 +233,7 @@ const DateRangeInput: React.FC<
   const nextMonth = currentMonth.add(1, 'month');
   return (
     <Box position="relative" zIndex={1} ref={targetRef}>
-      <Box onClick={onExpand} cursor="pointer">
+      <Box onClick={open}>
         <DoubleTextInput
           {...rest}
           variant={variant}
@@ -253,10 +247,18 @@ const DateRangeInput: React.FC<
           onChangeTo={noop}
           readOnly
           autoComplete="off"
-          icon="calendar"
         />
       </Box>
-      <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={open}>
+      <Flex align="center" position="absolute" right={3} top={0} bottom={0}>
+        <IconButton
+          variant="unstyled"
+          aria-label="Toggle picker"
+          size="medium"
+          icon="calendar"
+          onClick={toggle}
+        />
+      </Flex>
+      <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={isOpen}>
         <Flex justify="columns">
           {withPresets && (
             <Presets

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -153,13 +153,13 @@ const DateRangeInput: React.FC<
   );
 
   // Close on ESC key presses
-  useEscapeKey({ ref, callback: onCancel, disabled: !open });
+  useEscapeKey({ ref, callback: onCancel, disabled: !isOpen });
 
   // Close popover on clicks outside
   useOutsideClick({
     refs: [ref, targetRef],
     callback: onCancel,
-    disabled: !open,
+    disabled: !isOpen,
   });
 
   const formatDate = useCallback(
@@ -249,7 +249,7 @@ const DateRangeInput: React.FC<
           autoComplete="off"
         />
       </Box>
-      <Flex align="center" position="absolute" right={3} top={0} bottom={0}>
+      <Box position="absolute" top={2} right={3} zIndex={2}>
         <IconButton
           variant="unstyled"
           aria-label="Toggle picker"
@@ -257,7 +257,7 @@ const DateRangeInput: React.FC<
           icon="calendar"
           onClick={toggle}
         />
-      </Flex>
+      </Box>
       <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={isOpen}>
         <Flex justify="columns">
           {withPresets && (

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -11,6 +11,8 @@ import TimePicker from '../DateInput/TimePicker';
 import Month from '../DateInput/Month';
 import { TextInputProps } from '../TextInput';
 import { noop, getDates } from '../../utils/helpers';
+import useEscapeKey from '../../utils/useEscapeKey';
+import useOutsideClick from '../../utils/useOutsideClick';
 
 export interface DateRangeInputProps {
   /**
@@ -114,8 +116,7 @@ const DateRangeInput: React.FC<
 
   const [open, setOpen] = useState(false);
   const ref = React.useRef(null);
-
-  const nextMonth = currentMonth.add(1, 'month');
+  const targetRef = React.useRef(null);
 
   const onCancel = useCallback(() => {
     setCurrentRange(prevDateRange);
@@ -140,6 +141,7 @@ const DateRangeInput: React.FC<
     },
     [currentMonth, setCurrentMonth]
   );
+
   const onPreviousMonth = useCallback(
     e => {
       e.preventDefault();
@@ -148,6 +150,16 @@ const DateRangeInput: React.FC<
     },
     [currentMonth, setCurrentMonth]
   );
+
+  // Close on ESC key presses
+  useEscapeKey({ ref, callback: onCancel, disabled: !open });
+
+  // Close popover on clicks outside
+  useOutsideClick({
+    refs: [ref, targetRef],
+    callback: onCancel,
+    disabled: !open,
+  });
 
   const formatDate = useCallback(
     (values, key) => {
@@ -224,8 +236,9 @@ const DateRangeInput: React.FC<
     [setCurrentRange, currentDateRange]
   );
 
+  const nextMonth = currentMonth.add(1, 'month');
   return (
-    <Box position="relative" zIndex={1} ref={ref}>
+    <Box position="relative" zIndex={1} ref={targetRef}>
       <Box onClick={onExpand} cursor="pointer">
         <DoubleTextInput
           {...rest}
@@ -243,7 +256,7 @@ const DateRangeInput: React.FC<
           icon="calendar"
         />
       </Box>
-      <DateWrapper targetRef={ref} alignment={alignment} isExpanded={open}>
+      <DateWrapper ref={ref} targetRef={targetRef} alignment={alignment} isExpanded={open}>
         <Flex justify="columns">
           {withPresets && (
             <Presets

--- a/src/components/DateRangeInput/DoubleTextInput.tsx
+++ b/src/components/DateRangeInput/DoubleTextInput.tsx
@@ -2,7 +2,6 @@ import React, { ChangeEventHandler } from 'react';
 import Box from '../Box';
 import Flex from '../Flex';
 import { slugify } from '../../utils/helpers';
-import Icon, { IconProps } from '../Icon';
 import { TextInputProps } from '../TextInput';
 import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import { noop } from '../../utils/helpers';
@@ -38,9 +37,6 @@ export type DoubleTextInputProps = Omit<TextInputProps, 'label' | 'placeholder'>
 
   /** Whether the input is disabled or not */
   disabled?: boolean;
-
-  /** The icon present on the input  */
-  icon?: IconProps['type'];
 };
 
 const getIdentifier = (
@@ -71,7 +67,6 @@ const DoubleTextInput = React.forwardRef<HTMLInputElement, DoubleTextInputProps>
       hidden,
       name,
       variant = 'outline',
-      icon,
       from,
       to,
       placeholderFrom,
@@ -127,7 +122,6 @@ const DoubleTextInput = React.forwardRef<HTMLInputElement, DoubleTextInputProps>
                 {labelTo}
               </InputLabel>
             </Box>
-            {icon && <Icon size="medium" mx={4} type={icon} />}
           </Flex>
         </InputControl>
       </Box>

--- a/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
@@ -1,20 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`allows changing time options in 24h mode 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -25,15 +21,15 @@ exports[`allows changing time options in 24h mode 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -41,7 +37,7 @@ exports[`allows changing time options in 24h mode 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -141,7 +137,41 @@ exports[`allows changing time options in 24h mode 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -150,25 +180,23 @@ exports[`allows changing time options in 24h mode 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -212,38 +240,45 @@ exports[`allows changing time options in 24h mode 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`allows passing a custom format 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -254,15 +289,15 @@ exports[`allows passing a custom format 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -270,7 +305,7 @@ exports[`allows passing a custom format 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,7 +405,41 @@ exports[`allows passing a custom format 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -379,25 +448,23 @@ exports[`allows passing a custom format 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -441,38 +508,45 @@ exports[`allows passing a custom format 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`allows selecting a date range 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -483,15 +557,15 @@ exports[`allows selecting a date range 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -499,7 +573,7 @@ exports[`allows selecting a date range 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -599,7 +673,41 @@ exports[`allows selecting a date range 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -608,25 +716,23 @@ exports[`allows selecting a date range 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -670,38 +776,45 @@ exports[`allows selecting a date range 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`allows selecting a preset 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -712,15 +825,15 @@ exports[`allows selecting a preset 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -728,7 +841,7 @@ exports[`allows selecting a preset 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -828,7 +941,41 @@ exports[`allows selecting a preset 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -837,25 +984,23 @@ exports[`allows selecting a preset 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -899,38 +1044,45 @@ exports[`allows selecting a preset 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`opens the month picker 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -941,15 +1093,15 @@ exports[`opens the month picker 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -957,7 +1109,7 @@ exports[`opens the month picker 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1057,7 +1209,41 @@ exports[`opens the month picker 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1066,25 +1252,23 @@ exports[`opens the month picker 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -1128,38 +1312,45 @@ exports[`opens the month picker 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`opens the month picker with empty value 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1170,15 +1361,15 @@ exports[`opens the month picker with empty value 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1186,7 +1377,7 @@ exports[`opens the month picker with empty value 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1267,7 +1458,41 @@ exports[`opens the month picker with empty value 1`] = `
   border-radius: 4px;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1276,8 +1501,6 @@ exports[`opens the month picker with empty value 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 .pounce-1 {
@@ -1301,19 +1524,19 @@ exports[`opens the month picker with empty value 1`] = `
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -1357,38 +1580,45 @@ exports[`opens the month picker with empty value 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`opens the month picker with placement 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1399,15 +1629,15 @@ exports[`opens the month picker with placement 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1415,7 +1645,7 @@ exports[`opens the month picker with placement 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1515,7 +1745,41 @@ exports[`opens the month picker with placement 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1524,25 +1788,23 @@ exports[`opens the month picker with placement 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -1586,38 +1848,45 @@ exports[`opens the month picker with placement 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`renders 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1628,15 +1897,15 @@ exports[`renders 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1644,7 +1913,7 @@ exports[`renders 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1744,7 +2013,41 @@ exports[`renders 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1753,25 +2056,23 @@ exports[`renders 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -1815,38 +2116,45 @@ exports[`renders 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`renders with solid coloring 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1946,7 +2254,41 @@ exports[`renders with solid coloring 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -1955,11 +2297,9 @@ exports[`renders with solid coloring 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -1970,15 +2310,15 @@ exports[`renders with solid coloring 1`] = `
   border-color: #23344e;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1988,19 +2328,19 @@ exports[`renders with solid coloring 1`] = `
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -2044,38 +2384,45 @@ exports[`renders with solid coloring 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>
 `;
 
 exports[`renders with time options 1`] = `
-.pounce-11 {
+.pounce-13 {
   position: relative;
   z-index: 1;
-}
-
-.pounce-10 {
-  cursor: pointer;
 }
 
 .pounce-2 {
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -2086,15 +2433,15 @@ exports[`renders with time options 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -2102,7 +2449,7 @@ exports[`renders with time options 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2202,7 +2549,41 @@ exports[`renders with time options 1`] = `
   font-weight: 500;
 }
 
-.pounce-6 {
+.pounce-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  right: 12px;
+  top: 0;
+  bottom: 0;
+}
+
+.pounce-11 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-11:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-10 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -2211,25 +2592,23 @@ exports[`renders with time options 1`] = `
   width: 20px;
   height: 20px;
   color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
 }
 
 <div>
   <div
-    class="pounce-11"
+    class="pounce-13"
   >
     <div
-      class="pounce-10"
+      class="pounce-9"
     >
       <fieldset
         class="pounce-2"
       >
         <div
-          class="pounce-8"
+          class="pounce-7"
         >
           <div
-            class="pounce-7"
+            class="pounce-6"
           >
             <div
               class="pounce-2"
@@ -2273,18 +2652,29 @@ exports[`renders with time options 1`] = `
                 To date
               </label>
             </div>
-            <svg
-              class="pounce-6"
-              role="presentation"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-              />
-            </svg>
           </div>
         </div>
       </fieldset>
+    </div>
+    <div
+      class="pounce-12"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-11"
+        type="button"
+      >
+        <svg
+          class="pounce-10"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
     </div>
   </div>
 </div>

--- a/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
@@ -138,18 +138,10 @@ exports[`allows changing time options in 24h mode 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -406,18 +398,10 @@ exports[`allows passing a custom format 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -674,18 +658,10 @@ exports[`allows selecting a date range 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -942,18 +918,10 @@ exports[`allows selecting a preset 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -1210,18 +1178,10 @@ exports[`opens the month picker 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -1459,18 +1419,10 @@ exports[`opens the month picker with empty value 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -1746,18 +1698,10 @@ exports[`opens the month picker with placement 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -2014,18 +1958,10 @@ exports[`renders 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -2255,18 +2191,10 @@ exports[`renders with solid coloring 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {
@@ -2550,18 +2478,10 @@ exports[`renders with time options 1`] = `
 }
 
 .pounce-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   position: absolute;
+  top: 8px;
   right: 12px;
-  top: 0;
-  bottom: 0;
+  z-index: 2;
 }
 
 .pounce-11 {

--- a/src/components/DateRangeInput/__snapshots__/DoubleTextInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DoubleTextInput.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`renders with icons 1`] = `
   position: relative;
 }
 
-.pounce-8 {
+.pounce-7 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -389,15 +389,15 @@ exports[`renders with icons 1`] = `
   border-color: #3e516b;
 }
 
-.pounce-8:hover {
+.pounce-7:hover {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within {
+.pounce-7:focus-within {
   border-color: #0081c5;
 }
 
-.pounce-8:focus-within label {
+.pounce-7:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -405,7 +405,7 @@ exports[`renders with icons 1`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-7 {
+.pounce-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -505,28 +505,15 @@ exports[`renders with icons 1`] = `
   font-weight: 400;
 }
 
-.pounce-6 {
-  display: inline-block;
-  vertical-align: sub;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  color: currentColor;
-  margin-left: 16px;
-  margin-right: 16px;
-}
-
 <div>
   <fieldset
     class="pounce-2"
   >
     <div
-      class="pounce-8"
+      class="pounce-7"
     >
       <div
-        class="pounce-7"
+        class="pounce-6"
       >
         <div
           class="pounce-2"
@@ -564,15 +551,6 @@ exports[`renders with icons 1`] = `
             Surname
           </label>
         </div>
-        <svg
-          class="pounce-6"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12.09 2.90995C10.08 0.899954 7.07 0.489954 4.65 1.66995L8.99 6.00995L5.99 9.00995L1.65 4.66995C0.480003 7.09995 0.890003 10.09 2.9 12.1C4.76 13.96 7.48 14.45 9.79 13.58L19.61 23.4L23.32 19.69L13.54 9.89995C14.46 7.55995 13.98 4.79995 12.09 2.90995V2.90995Z"
-          />
-        </svg>
       </div>
     </div>
   </fieldset>
@@ -580,10 +558,10 @@ exports[`renders with icons 1`] = `
     class="pounce-2"
   >
     <div
-      class="pounce-8"
+      class="pounce-7"
     >
       <div
-        class="pounce-7"
+        class="pounce-6"
       >
         <div
           class="pounce-2"
@@ -621,15 +599,6 @@ exports[`renders with icons 1`] = `
             Surname
           </label>
         </div>
-        <svg
-          class="pounce-6"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
-          />
-        </svg>
       </div>
     </div>
   </fieldset>
@@ -637,10 +606,10 @@ exports[`renders with icons 1`] = `
     class="pounce-2"
   >
     <div
-      class="pounce-8"
+      class="pounce-7"
     >
       <div
-        class="pounce-7"
+        class="pounce-6"
       >
         <div
           class="pounce-2"
@@ -678,15 +647,6 @@ exports[`renders with icons 1`] = `
             Surname
           </label>
         </div>
-        <svg
-          class="pounce-6"
-          role="presentation"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M7 10L12 15L17 10H7Z"
-          />
-        </svg>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
### Background

The `DateRangePicker` and `DateInput` components don't allow the user to close the popup, unless he/she presses the "Cancel" button. 

After user feedback, this PR changes that, allowing the user to:

- Close the popup when the user clicks outside
- Close the popup when the user presses ESC while having the popup on focus
- Toggle the popup when the calendar icon button is clicked

Whenever the popup closes, the user's selection is also reset

Closes https://github.com/panther-labs/panther/issues/1836

### Changes

- Remove `icon` from input and replace with interactive `IconButton`
- Add `forwardRef` to `DateWrapper`
- Utilize `useOutsideClick` and `useESCKeypress` inside `DateRangePicker` and `DateInput`
- Update snaps

### Testing

- `npm run test`
