### PR TITLE
fix: close calendar on selection application

### DIFF
--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -130,6 +130,25 @@ describe('DateInput', () => {
     expect(mock).toHaveBeenCalled();
   });
 
+  it('closes when a selection is applied', async () => {
+    const mock = jest.fn();
+    const { getByLabelText, findByLabelText, findByText, getByText } = await renderWithTheme(
+      <DateInput label="test" value={date.toDate()} onChange={mock} />
+    );
+
+    // Open the date input components
+    fireEvent.click(getByLabelText('test'));
+    fireEvent.click(await findByLabelText('Su Nov 01 2020'));
+
+    const dateHeader = await findByText('November 2020');
+    expect(dateHeader).toBeInTheDocument();
+
+    fireEvent.click(getByText('Apply'));
+
+    await waitForElementToBeRemoved(dateHeader);
+    expect(dateHeader).not.toBeInTheDocument();
+  });
+
   it('closes on an outside click', async () => {
     const mock = jest.fn();
     const { container, findByLabelText, findByText } = await renderWithTheme(

--- a/src/components/DateRangeInput/DateRangeInput.test.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.test.tsx
@@ -295,3 +295,44 @@ it('closes on an outside click', async () => {
   await waitForElementToBeRemoved(dateHeader);
   expect(dateHeader).not.toBeInTheDocument();
 });
+
+it('closes when a selection is applied', async () => {
+  const mock = jest.fn();
+  const { findByLabelText, getByText } = await renderWithTheme(
+    <DateRangeInput {...props} onChange={mock} />
+  );
+
+  // Open the date input components
+  fireEvent.click(await findByLabelText('From date'));
+  fireEvent.click(await findByLabelText('Su Nov 01 2020'));
+  fireEvent.click(await findByLabelText('Mo Nov 30 2020'));
+
+  const dateHeader = getByText('November 2020');
+  expect(dateHeader).toBeInTheDocument();
+
+  fireEvent.click(getByText('Apply'));
+
+  await waitForElementToBeRemoved(dateHeader);
+  expect(dateHeader).not.toBeInTheDocument();
+});
+
+it('toggles when the calendar icon is clicked', async () => {
+  const mock = jest.fn();
+  const { container, findByText } = await renderWithTheme(
+    <DateRangeInput {...props} onChange={mock} />
+  );
+  const calendarIconButton = container.querySelector(
+    '[aria-label="Toggle picker"]'
+  ) as HTMLButtonElement;
+
+  // Open the date input components
+  fireEvent.click(calendarIconButton);
+
+  const dateHeader = await findByText('November 2020');
+  expect(dateHeader).toBeInTheDocument();
+
+  fireEvent.click(calendarIconButton);
+
+  await waitForElementToBeRemoved(dateHeader);
+  expect(dateHeader).not.toBeInTheDocument();
+});

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -129,7 +129,7 @@ const DateRangeInput: React.FC<
       e.preventDefault();
       setPrevDateRange(currentDateRange);
       onChange(currentDateRange);
-      close;
+      close();
     },
     [close, setPrevDateRange, onChange, currentDateRange]
   );


### PR DESCRIPTION
### Background

There is a small bug and the calendar doesn't close when a selection is made. This PR fixes that, making sure it closes whenever the "Apply" button is clicked

### Changes

- Fix typo
- Write tests for it

### Testing

- `npm run test`
