### PR TITLE
Fix raising input labels

### DIFF
--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NativeAttributes } from '../Box';
-import { slugify, noop } from '../../utils/helpers';
+import { slugify, noop, isEmpty } from '../../utils/helpers';
 import { typedMemo } from '../../utils/helpers';
 import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import AbstractButton from '../AbstractButton';
@@ -111,7 +111,7 @@ function NumberInput({
         ref={_ref}
         {...inputNumberProps}
       />
-      <InputLabel raised={value !== undefined} htmlFor={identifier}>
+      <InputLabel raised={!isEmpty(value)} htmlFor={identifier}>
         {label}
       </InputLabel>
       <Flex

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NativeAttributes } from '../Box';
-import { slugify, noop, isEmpty } from '../../utils/helpers';
+import { slugify, noop, isEmptyValue } from '../../utils/helpers';
 import { typedMemo } from '../../utils/helpers';
 import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import AbstractButton from '../AbstractButton';
@@ -111,7 +111,7 @@ function NumberInput({
         ref={_ref}
         {...inputNumberProps}
       />
-      <InputLabel raised={!isEmpty(value)} htmlFor={identifier}>
+      <InputLabel raised={!isEmptyValue(value)} htmlFor={identifier}>
         {label}
       </InputLabel>
       <Flex

--- a/src/components/TextInput/TextInput.mdx
+++ b/src/components/TextInput/TextInput.mdx
@@ -61,14 +61,27 @@ An input can be disabled:
 <TextInput label="Name" name="hi" disabled placeholder="Type something..." value="Disabled Value" />
 ```
 
+An input can have a `type="number"`:
+
+```typescript jsx
+<TextInput
+  label="Name with number"
+  type="number"
+  variant="solid"
+  name="hi"
+  placeholder="Type something..."
+  value="9"
+/>
+```
+
 An input can be "solid":
 
 ```typescript jsx
 <TextInput
-  label="Name"
+  label="Name with variant"
   variant="solid"
   name="hi"
   placeholder="Type something..."
-  value="Disabled Value"
+  value="Solid"
 />
 ```

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -7,6 +7,13 @@ it('renders', async () => {
   expect(container).toMatchSnapshot();
 });
 
+it('renders with different type', async () => {
+  const { container } = await renderWithTheme(
+    <TextInput label="Num input" type="number" value="0" />
+  );
+  expect(container).toMatchSnapshot();
+});
+
 it('renders with disabled option', async () => {
   const { container } = await renderWithTheme(<TextInput label="Text input disabled" disabled />);
   expect(container).toMatchSnapshot();

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NativeAttributes } from '../Box';
-import { slugify } from '../../utils/helpers';
+import { slugify, isEmpty } from '../../utils/helpers';
 import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import Icon, { IconProps } from '../Icon';
 import Flex from '../Flex';
@@ -57,7 +57,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function Te
   ref
 ) {
   const identifier = id || name || slugify(label);
-
   return (
     <InputControl
       variant={variant}
@@ -82,7 +81,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function Te
           ref={ref}
         />
         <InputLabel
-          raised={!!value}
+          raised={!isEmpty(value)}
           htmlFor={identifier}
           left={icon && iconAlignment === 'left' ? 26 : null}
         >

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NativeAttributes } from '../Box';
-import { slugify, isEmpty } from '../../utils/helpers';
+import { slugify, isEmptyValue } from '../../utils/helpers';
 import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import Icon, { IconProps } from '../Icon';
 import Flex from '../Flex';
@@ -81,7 +81,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(function Te
           ref={ref}
         />
         <InputLabel
-          raised={!isEmpty(value)}
+          raised={!isEmptyValue(value)}
           htmlFor={identifier}
           left={icon && iconAlignment === 'left' ? 26 : null}
         >

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -156,6 +156,162 @@ exports[`renders 1`] = `
 </div>
 `;
 
+exports[`renders with different type 1`] = `
+.pounce-3 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: transparent;
+  border-radius: 4px;
+  border-color: #3e516b;
+}
+
+.pounce-3:hover {
+  border-color: #0081c5;
+}
+
+.pounce-3:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-3:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+}
+
+.pounce-0 {
+  vertical-align: top;
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: relative;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  z-index: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+<div>
+  <div
+    class="pounce-3"
+  >
+    <div
+      class="pounce-2"
+    >
+      <input
+        aria-invalid="false"
+        class="pounce-0"
+        id="num-input"
+        type="number"
+        value="0"
+      />
+      <label
+        class="pounce-1"
+        for="num-input"
+      >
+        Num input
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders with disabled option 1`] = `
 .pounce-3 {
   min-height: 47px;

--- a/src/utils/helpers.test.tsx
+++ b/src/utils/helpers.test.tsx
@@ -1,0 +1,13 @@
+import { isEmpty } from './helpers';
+
+it('isEmpty', () => {
+  expect(isEmpty(undefined)).toBeTruthy();
+  expect(isEmpty(null)).toBeTruthy();
+  expect(isEmpty('')).toBeTruthy();
+  expect(isEmpty('    ')).toBeFalsy();
+  expect(isEmpty('1  ')).toBeFalsy();
+  expect(isEmpty('1')).toBeFalsy();
+  expect(isEmpty(0)).toBeFalsy();
+  expect(isEmpty(1)).toBeFalsy();
+  expect(isEmpty(2)).toBeFalsy();
+});

--- a/src/utils/helpers.test.tsx
+++ b/src/utils/helpers.test.tsx
@@ -1,4 +1,24 @@
-import { isEmpty } from './helpers';
+import { isEmpty, addOpacity, lightenDarkenColor, slugify } from './helpers';
+
+it('addOpacity', () => {
+  expect(addOpacity('#86a3c3', 0.1)).toMatchInlineSnapshot(`"rgba(134,163,195,0.1)"`);
+  expect(addOpacity('#3e516b', 0.1)).toMatchInlineSnapshot(`"rgba(62,81,107,0.1)"`);
+  expect(addOpacity('#4f4f4f', 1)).toMatchInlineSnapshot(`"rgba(79,79,79,1)"`);
+  expect(addOpacity('#073e73', 0.5)).toMatchInlineSnapshot(`"rgba(7,62,115,0.5)"`);
+});
+
+it('lightenDarkenColor', () => {
+  expect(lightenDarkenColor('#86a3c3', 85)).toMatchInlineSnapshot(`"#dbf8ff"`);
+  expect(lightenDarkenColor('#3e516b', -8)).toMatchInlineSnapshot(`"#364963"`);
+  expect(lightenDarkenColor('#073e73', 25)).toMatchInlineSnapshot(`"#20578c"`);
+});
+
+it('lightenDarkenColor', () => {
+  expect(slugify('')).toMatchInlineSnapshot(`""`);
+  expect(slugify('hELLO WORLD')).toMatchInlineSnapshot(`"hello-world"`);
+  expect(slugify('👋  hello 👋  world - again ')).toMatchInlineSnapshot(`"hello-world-again"`);
+  expect(slugify('-----hello---world------')).toMatchInlineSnapshot(`"hello-world"`);
+});
 
 it('isEmpty', () => {
   expect(isEmpty(undefined)).toBeTruthy();

--- a/src/utils/helpers.test.tsx
+++ b/src/utils/helpers.test.tsx
@@ -1,4 +1,4 @@
-import { isEmpty, addOpacity, lightenDarkenColor, slugify } from './helpers';
+import { isEmptyValue, addOpacity, lightenDarkenColor, slugify } from './helpers';
 
 it('addOpacity', () => {
   expect(addOpacity('#86a3c3', 0.1)).toMatchInlineSnapshot(`"rgba(134,163,195,0.1)"`);
@@ -20,14 +20,20 @@ it('lightenDarkenColor', () => {
   expect(slugify('-----hello---world------')).toMatchInlineSnapshot(`"hello-world"`);
 });
 
-it('isEmpty', () => {
-  expect(isEmpty(undefined)).toBeTruthy();
-  expect(isEmpty(null)).toBeTruthy();
-  expect(isEmpty('')).toBeTruthy();
-  expect(isEmpty('    ')).toBeFalsy();
-  expect(isEmpty('1  ')).toBeFalsy();
-  expect(isEmpty('1')).toBeFalsy();
-  expect(isEmpty(0)).toBeFalsy();
-  expect(isEmpty(1)).toBeFalsy();
-  expect(isEmpty(2)).toBeFalsy();
+it('isEmptyValue', () => {
+  expect(isEmptyValue(undefined)).toBeTruthy();
+  expect(isEmptyValue(null)).toBeTruthy();
+  expect(isEmptyValue('')).toBeTruthy();
+  expect(isEmptyValue([])).toBeTruthy();
+  expect(isEmptyValue({})).toBeTruthy();
+
+  expect(isEmptyValue('    ')).toBeFalsy();
+  expect(isEmptyValue('1  ')).toBeFalsy();
+  expect(isEmptyValue('1')).toBeFalsy();
+
+  expect(isEmptyValue(['1'])).toBeFalsy();
+  expect(isEmptyValue({ a: '1' })).toBeFalsy();
+  expect(isEmptyValue(0)).toBeFalsy();
+  expect(isEmptyValue(1)).toBeFalsy();
+  expect(isEmptyValue(2)).toBeFalsy();
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -72,6 +72,18 @@ export const isBrowser = typeof window !== 'undefined' && typeof window.document
 
 export const noop = (): void => {};
 
+export const isEmpty = (value?: string | number | readonly string[] | undefined): boolean => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string' && value === '') {
+    return true;
+  }
+
+  return false;
+};
+
 /**
  * A function that generates a preset with dynamic dates.
  * @returns {Object} An object with Dayjs presets

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -72,12 +72,22 @@ export const isBrowser = typeof window !== 'undefined' && typeof window.document
 
 export const noop = (): void => {};
 
-export const isEmpty = (value?: string | number | readonly string[] | undefined): boolean => {
+export const isEmptyValue = (
+  value?: string | number | Record<string, unknown> | readonly string[] | undefined
+): boolean => {
   if (value === null || value === undefined) {
     return true;
   }
 
   if (typeof value === 'string' && value === '') {
+    return true;
+  }
+
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+
+  if (typeof value === 'object' && Object.keys(value).length === 0) {
     return true;
   }
 


### PR DESCRIPTION
### Background

Input labels were a bit off, raised upon values that made no sense. This PR introduces a tiny helper to accommodate empty input values (`null`, `undefined`, `''`). Even a single space can be valid though.

### Changes

- Added `isEmpty` helper
- Consumed the helper for `TextInput` and `NumberInput` components.
- Added helper tests and examples.

### Testing

- Visually
- `npm run test`
