### PR TITLE
fix: add hours range from 00 to 23 in 24h format

### DIFF
--- a/src/components/DateInput/DateInput.mdx
+++ b/src/components/DateInput/DateInput.mdx
@@ -95,7 +95,7 @@ const DateInputExampleWithTime = () => {
 <DateInputExampleWithTime />;
 ```
 
-It supports manipulating the given time in 12h format
+It supports manipulating the given time in 24h format
 
 ```typescript jsx
 const DateInputExampleWithTime = () => {
@@ -108,7 +108,7 @@ const DateInputExampleWithTime = () => {
       <Box>
         <DateInput
           withTime
-          mode="12h"
+          mode="24h"
           format="MM/DD/YYYY HH:mm A"
           onChange={setDate}
           value={date}

--- a/src/components/DateInput/DateInput.test.tsx
+++ b/src/components/DateInput/DateInput.test.tsx
@@ -90,6 +90,18 @@ describe('DateInput', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('allows selecting a date with time options in 24h mode', async () => {
+    const mock = jest.fn();
+    const { findByLabelText, container } = await renderWithTheme(
+      <DateInput label="test" mode="24h" value={date.toDate()} withTime onChange={mock} />
+    );
+    const input = await findByLabelText('test');
+
+    // Open the date input components
+    await fireEvent.click(input);
+    expect(container).toMatchSnapshot();
+  });
+
   it('allows selecting a date with time options in 12h mode', async () => {
     const mock = jest.fn();
     const { findByLabelText, container } = await renderWithTheme(

--- a/src/components/DateInput/TimePicker.tsx
+++ b/src/components/DateInput/TimePicker.tsx
@@ -6,7 +6,8 @@ import { slugify } from '../../utils/helpers';
 
 const getHourItems = (mode: string) => {
   const limit = mode === '12h' ? 12 : 24;
-  return Array.from(Array(limit), (_, i) => `0${i + 1}`.slice(-2));
+  const gap = mode === '12h' ? 1 : 0;
+  return Array.from(Array(limit), (_, i) => `0${i + gap}`.slice(-2));
 };
 
 const minsItems = Array.from(Array(60), (_, i) => `0${i}`.slice(-2));
@@ -36,6 +37,7 @@ const TimePicker: React.FC<TimePickerProps> = ({
   const periodLabel = React.useMemo(() => `${label} Period`.trim(), [label]);
 
   const hourItems = getHourItems(mode);
+
   const onChangeHours = React.useCallback(
     hour => {
       const d = dayjs(date).hour(hour);

--- a/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -678,6 +678,232 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
 </div>
 `;
 
+exports[`DateInput allows selecting a date with time options in 24h mode 1`] = `
+.pounce-7 {
+  position: relative;
+}
+
+.pounce-3 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: transparent;
+  border-radius: 4px;
+  border-color: #3e516b;
+}
+
+.pounce-3:hover {
+  border-color: #0081c5;
+}
+
+.pounce-3:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-3:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+}
+
+.pounce-0 {
+  vertical-align: top;
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: relative;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  z-index: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-6 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2;
+}
+
+.pounce-5 {
+  outline: none;
+  line-height: 1;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-5:focus {
+  border-radius: 99999px;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: currentColor;
+}
+
+<div>
+  <div
+    class="pounce-7"
+  >
+    <div
+      class="pounce-3"
+    >
+      <div
+        class="pounce-2"
+      >
+        <input
+          aria-autocomplete="none"
+          aria-invalid="false"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="test"
+          readonly=""
+          tabindex="-1"
+          type="text"
+          value="11/01/2020"
+        />
+        <label
+          class="pounce-1"
+          for="test"
+        >
+          test
+        </label>
+      </div>
+    </div>
+    <div
+      class="pounce-6"
+    >
+      <button
+        aria-label="Toggle picker"
+        aria-pressed="false"
+        class="pounce-5"
+        type="button"
+      >
+        <svg
+          class="pounce-4"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,4 L18,4 L18,2 L16,2 L16,4 L8,4 L8,2 L6,2 L6,4 L5,4 C3.89,4 3.01,4.9 3.01,6 L3,20 C3,21.1 3.89,22 5,22 L19,22 C20.1,22 21,21.1 21,20 L21,6 C21,4.9 20.1,4 19,4 Z M19,20 L5,20 L5,9 L19,9 L19,20 Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DateInput can be solid 1`] = `
 .pounce-7 {
   position: relative;

--- a/src/components/DateRangeInput/DateRangeInput.test.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.test.tsx
@@ -202,6 +202,52 @@ it('allows changing time options in 12h mode', async () => {
   expect(ending.format('DD/MM/YYYY HH:mm A')).toBe('11/11/2020 07:22 AM');
 });
 
+it.only('allows changing time options in 24h mode', async () => {
+  const mock = jest.fn();
+  const endDate = end.add(3, 'hour').minute(59);
+
+  const { findByLabelText, getByLabelText, findByText, findByTestId } = await renderWithTheme(
+    <DateRangeInput
+      value={[start.toDate(), endDate.toDate()]}
+      id="test-hours"
+      mode="24h"
+      labelStart="From date"
+      labelEnd="To date"
+      withTime
+      onChange={mock}
+    />
+  );
+  const input = await findByLabelText('From date');
+  // Open the date input components
+  await fireEvent.click(input);
+
+  const endingHours = await getByLabelText('To Time Hours', { selector: 'input' });
+  const endingMinutes = await getByLabelText('To Time Minutes', { selector: 'input' });
+
+  expect(endingHours.value).toBe('04');
+  expect(endingMinutes.value).toBe('59');
+
+  await fireEvent.focus(endingHours);
+  const twelve = await findByTestId('to-time-hours-00');
+  await fireEvent.click(twelve);
+
+  await fireEvent.focus(endingMinutes);
+  const fiftyMinutes = await findByTestId('to-time-minutes-22');
+  await fireEvent.click(fiftyMinutes);
+
+  const submitBtn = await findByText('Apply');
+  await fireEvent.click(submitBtn);
+  expect(mock).toHaveBeenCalled();
+
+  const starting = dayjs(mock.mock.calls[0][0][0]);
+  const ending = dayjs(mock.mock.calls[0][0][1]);
+
+  // Format and assert dates without timezones in order to make it work
+  // across workstations and the CI
+  expect(starting.format('DD/MM/YYYY HH:mm A')).toBe('01/11/2020 01:02 AM');
+  expect(ending.format('DD/MM/YYYY HH:mm A')).toBe('11/11/2020 00:22 AM');
+});
+
 it('allows passing a custom format', async () => {
   const mock = jest.fn();
   const format = 'M MMM YYYY D dd';


### PR DESCRIPTION
### Background

This one adds a new range for 24h format date pickers.


### Screenshot
![Screenshot 2020-11-12 at 9 20 37 PM](https://user-images.githubusercontent.com/1022166/98985992-fc807d80-252c-11eb-8f41-7b07ca1e89d9.png)


### Changes

- For 24h format we are adding hours as 00 ... 23

### Testing

- `npm run test`
