### PR TITLE
Fix duplicate combobox input

### DIFF
--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -330,10 +330,11 @@ function MultiCombobox<Item>({
                       {isOpen && searchable && (
                         <InputElement
                           as="span"
-                          px={2}
+                          px={1}
                           py={0}
                           standalone={hideLabel}
                           visibility="hidden"
+                          color="transparent"
                           whiteSpace="pre"
                         >
                           {inputValue}


### PR DESCRIPTION
### Background

Fixes a bug where the combo box input was rendered twice in Firefox

### Changes

- Hide/Remove the duplicate input

### Testing

- Locally
