### PR TITLE
fix: TabList & TabPanel can accept null children

### DIFF
--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -14,14 +14,12 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(function T
   return (
     // @ts-ignore Typing is wrong on @reach-ui, allowing only div | undefined for `as`
     <ReachTabList as={Flex} ref={ref} flexWrap="wrap" {...rest}>
-      {React.Children.toArray(children)
-        .filter(Boolean)
-        .map((child, index) =>
-          React.cloneElement(child as React.ReactElement, {
-            isSelected: selectedIndex === index,
-            isFocused: focusedIndex === index,
-          })
-        )}
+      {React.Children.toArray(children).map((child, index) =>
+        React.cloneElement(child as React.ReactElement, {
+          isSelected: selectedIndex === index,
+          isFocused: focusedIndex === index,
+        })
+      )}
     </ReachTabList>
   );
 });

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -14,15 +14,14 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(function T
   return (
     // @ts-ignore Typing is wrong on @reach-ui, allowing only div | undefined for `as`
     <ReachTabList as={Flex} ref={ref} flexWrap="wrap" {...rest}>
-      {React.Children.map(children, (child, index) => {
-        if (child) {
-          return React.cloneElement(child as React.ReactElement, {
+      {React.Children.toArray(children)
+        .filter(Boolean)
+        .map((child, index) =>
+          React.cloneElement(child as React.ReactElement, {
             isSelected: selectedIndex === index,
             isFocused: focusedIndex === index,
-          });
-        }
-        return null;
-      })}
+          })
+        )}
     </ReachTabList>
   );
 });

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -14,12 +14,15 @@ export const TabList = React.forwardRef<HTMLDivElement, TabListProps>(function T
   return (
     // @ts-ignore Typing is wrong on @reach-ui, allowing only div | undefined for `as`
     <ReachTabList as={Flex} ref={ref} flexWrap="wrap" {...rest}>
-      {React.Children.map(children, (child, index) =>
-        React.cloneElement(child as React.ReactElement, {
-          isSelected: selectedIndex === index,
-          isFocused: focusedIndex === index,
-        })
-      )}
+      {React.Children.map(children, (child, index) => {
+        if (child) {
+          return React.cloneElement(child as React.ReactElement, {
+            isSelected: selectedIndex === index,
+            isFocused: focusedIndex === index,
+          });
+        }
+        return null;
+      })}
     </ReachTabList>
   );
 });

--- a/src/components/Tabs/TabPanels.tsx
+++ b/src/components/Tabs/TabPanels.tsx
@@ -9,12 +9,9 @@ const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(function TabP
 ) {
   return (
     <ReachTabPanels ref={ref} {...rest}>
-      {React.Children.map(children, (child, index) => {
-        if (child) {
-          return React.cloneElement(child as React.ReactElement, { index });
-        }
-        return null;
-      })}
+      {React.Children.toArray(children)
+        .filter(Boolean)
+        .map((child, index) => React.cloneElement(child as React.ReactElement, { index }))}
     </ReachTabPanels>
   );
 });

--- a/src/components/Tabs/TabPanels.tsx
+++ b/src/components/Tabs/TabPanels.tsx
@@ -9,9 +9,9 @@ const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(function TabP
 ) {
   return (
     <ReachTabPanels ref={ref} {...rest}>
-      {React.Children.toArray(children)
-        .filter(Boolean)
-        .map((child, index) => React.cloneElement(child as React.ReactElement, { index }))}
+      {React.Children.toArray(children).map((child, index) =>
+        React.cloneElement(child as React.ReactElement, { index })
+      )}
     </ReachTabPanels>
   );
 });

--- a/src/components/Tabs/TabPanels.tsx
+++ b/src/components/Tabs/TabPanels.tsx
@@ -9,9 +9,12 @@ const TabPanels = React.forwardRef<HTMLDivElement, TabPanelsProps>(function TabP
 ) {
   return (
     <ReachTabPanels ref={ref} {...rest}>
-      {React.Children.map(children, (child, index) =>
-        React.cloneElement(child as React.ReactElement, { index })
-      )}
+      {React.Children.map(children, (child, index) => {
+        if (child) {
+          return React.cloneElement(child as React.ReactElement, { index });
+        }
+        return null;
+      })}
     </ReachTabPanels>
   );
 });


### PR DESCRIPTION
### Background

There are occasions where some tabs must be rendered conditionally thus should render null instead of children

### Changes

- Added check if child is defined before cloning

### Testing

- Used branch for local development
