### PR TITLE
Input number hide arrows for Firefox

### DIFF
--- a/src/components/utils/Input/InputElement.tsx
+++ b/src/components/utils/Input/InputElement.tsx
@@ -20,6 +20,7 @@ const InputElement = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, In
     const theme = useTheme();
     const pt = standalone ? 14 : 5;
     const pb = standalone ? 14 : 2;
+
     return (
       <Box
         ref={ref}

--- a/src/utils/GlobalStyles.tsx
+++ b/src/utils/GlobalStyles.tsx
@@ -194,7 +194,7 @@ const GlobalStyles: React.FC = () => {
     input[type='number'] {
       -webkit-appearance: textfield;
       -moz-appearance: textfield;
-      appearance: initial;
+      appearance: textfield;
     }
     input[type='number']::-webkit-inner-spin-button,
     input[type='number']::-webkit-outer-spin-button {


### PR DESCRIPTION
### Background

Firefox is a bit strict in order to hide the spinners, thus this PR uses the appearance property as it can be seen [here](https://developer.mozilla.org/en-US/docs/Web/CSS/appearance) in order to prevent showing the arrows in Firefox.

### Changes

- Change appearance global and inline rules.
