### PR TITLE
Checkbox indeterminate state

### DIFF
--- a/src/components/Checkbox/Checkbox.mdx
+++ b/src/components/Checkbox/Checkbox.mdx
@@ -4,6 +4,7 @@ const Example = () => {
   const [isCheckedB, setCheckedB] = React.useState(false);
   const [isCheckedC, setCheckedC] = React.useState(false);
   const [isCheckedD, setCheckedD] = React.useState(false);
+  const [isCheckedE, setCheckedE] = React.useState(false);
   return (
     <Box>
       <Box>
@@ -29,12 +30,17 @@ const Example = () => {
         />
       </Box>
       <Box>
-        <Checkbox indeterminate label="Indeterminate" />
+        <Checkbox
+          checked={isCheckedD}
+          indeterminate
+          label="Indeterminate"
+          onChange={e => setCheckedD(e.target.checked)}
+        />
       </Box>
       <Box>
         <Checkbox
-          checked={isCheckedD}
-          onChange={e => setCheckedD(e.target.checked)}
+          checked={isCheckedE}
+          onChange={e => setCheckedE(e.target.checked)}
           label="Disabled"
           disabled
         />

--- a/src/components/Checkbox/Checkbox.mdx
+++ b/src/components/Checkbox/Checkbox.mdx
@@ -29,6 +29,9 @@ const Example = () => {
         />
       </Box>
       <Box>
+        <Checkbox indeterminate label="Indeterminate" />
+      </Box>
+      <Box>
         <Checkbox
           checked={isCheckedD}
           onChange={e => setCheckedD(e.target.checked)}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,16 +11,19 @@ export type CheckboxProps = NativeAttributes<'input'> & {
 
   /**  Whether the input has an invalid value or not */
   invalid?: boolean;
+
+  /**  Whether the input state cannot be determined in binary terms */
+  indeterminate?: boolean;
 };
 
 /**
  *  Your bread & butter checkbox element. Nothing new here
  *  */
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
-  { checked, label, disabled, readOnly, invalid, hidden, ...rest },
+  { checked, label, disabled, readOnly, invalid, indeterminate, hidden, ...rest },
   ref
 ) {
-  const checkboxStyles = useCheckboxStyles({ invalid, checked });
+  const checkboxStyles = useCheckboxStyles({ invalid, checked, indeterminate });
 
   if (!label && !(rest['aria-label'] || rest['aria-labelledby'])) {
     console.error(

--- a/src/components/Checkbox/useCheckboxStyles.tsx
+++ b/src/components/Checkbox/useCheckboxStyles.tsx
@@ -25,9 +25,9 @@ const useCheckboxStyles = ({ invalid, checked, indeterminate }: UseCheckboxStyle
         },
       },
       _before: {
-        content: indeterminate
-          ? `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 18" fill="white"><path d="M20 13.8571V13.1429H4V10.8571H10.1429V10.8571H20V13.1429Z"/></svg>' )`
-          : `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 18" fill="white"><path d="M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42L7 14.17z" /></svg>' )`,
+        content: checked
+          ? `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 18" fill="white"><path d="M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42L7 14.17z" /></svg>' )`
+          : `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 18" fill="white"><path d="M20 13.8571V13.1429H4V10.8571H10.1429V10.8571H20V13.1429Z"/></svg>' )`,
         display: 'block',
         position: 'absolute',
         width: 'fit-content',

--- a/src/components/Checkbox/useCheckboxStyles.tsx
+++ b/src/components/Checkbox/useCheckboxStyles.tsx
@@ -4,9 +4,9 @@ import { addOpacity } from '../../utils/helpers';
 import { CheckboxProps } from './Checkbox';
 import useTheme from '../../utils/useTheme';
 
-type UseCheckboxStyles = Pick<CheckboxProps, 'invalid' | 'checked'>;
+type UseCheckboxStyles = Pick<CheckboxProps, 'invalid' | 'checked' | 'indeterminate'>;
 
-const useCheckboxStyles = ({ invalid, checked }: UseCheckboxStyles): BoxProps => {
+const useCheckboxStyles = ({ invalid, checked, indeterminate }: UseCheckboxStyles): BoxProps => {
   const theme = useTheme();
 
   return React.useMemo(
@@ -25,12 +25,14 @@ const useCheckboxStyles = ({ invalid, checked }: UseCheckboxStyles): BoxProps =>
         },
       },
       _before: {
-        content: `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 18" fill="white"><path d="M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42L7 14.17z" /></svg>' )`,
+        content: indeterminate
+          ? `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 18" fill="white"><path d="M20 13.8571V13.1429H4V10.8571H10.1429V10.8571H20V13.1429Z"/></svg>' )`
+          : `url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 18" fill="white"><path d="M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42L7 14.17z" /></svg>' )`,
         display: 'block',
         position: 'absolute',
         width: 'fit-content',
         height: 'fit-content',
-        opacity: checked ? 1 : 0,
+        opacity: checked || indeterminate ? 1 : 0,
         transition: 'opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
         top: 0,
         left: 0,


### PR DESCRIPTION
### Background

Right now, the `Checkbox` component only accepts `selected: boolean`, but there are occasions i.e. when this checkbox is used as a select-all checkbox that we need to have a third "semi" selected state.

### Changes

- Add "semi" state in Checkbox component

### Screenshots
![image](https://user-images.githubusercontent.com/15084305/117681787-1e487d80-b1bb-11eb-8875-17d29610849c.png)

### Testing

- Manually
