### PR TITLE
Fix: pasting JSON into the multicombo box over-tokenizes

### DIFF
--- a/src/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.test.tsx
@@ -253,6 +253,24 @@ describe('MultiCombobox', () => {
     expect(queryAllByRole('tag')).toHaveLength(2);
   });
 
+  it("appends and doesn't replace when pasting", async () => {
+    const { getByPlaceholderText, queryAllByRole } = renderWithTheme(
+      <ControlledMultiCombobox searchable allowAdditions />
+    );
+
+    const input = getByPlaceholderText('Select manufacturers');
+
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Random Value 1\r\n\r\n\r\nRandom Value 2' },
+    });
+    expect(queryAllByRole('tag')).toHaveLength(2);
+
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Random Value 3\r\n\r\n\r\nRandom Value 4' },
+    });
+    expect(queryAllByRole('tag')).toHaveLength(4);
+  });
+
   it('works when selecting grouped items', async () => {
     const { getByPlaceholderText, queryAllByRole, container } = renderWithTheme(
       <ControlledMultiCombobox itemToGroup={i => i.category} itemToString={i => i.value} />

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -307,9 +307,12 @@ function MultiCombobox<Item>({
                 e.stopPropagation();
 
                 // extend existing values with new ones
-                onChange(
-                  ([...items].map(processUserValue).filter(validateUserValue) as unknown) as Item[]
-                );
+                onChange([
+                  ...value,
+                  ...(([...items]
+                    .map(processUserValue)
+                    .filter(validateUserValue) as unknown) as Item[]),
+                ]);
               }
             };
 


### PR DESCRIPTION
### Background

@willow9886 reported: https://www.loom.com/share/fce9c1ed0c7f4bb69ed7f247fb9fca5d

Pasting a JSON dictionary or array litters a Multicomboxbox with tokens. I was going to file but realized that fixing it was probably faster than putting this into the sprint board and discussing it with someone

https://app.asana.com/0/1200001670318539/1200495389667105

### Changes

Pasting a JSON dictionary pastes the keys (I don't know what the right behavior is, but it's better than what we had)

### Testing

Wrote unit tests, tested on the documentation page
