### PR TITLE
refactor: move from relative to absolute paths

### DIFF
--- a/jest/config.js
+++ b/jest/config.js
@@ -1,4 +1,13 @@
+const fromPairs = require('lodash/fromPairs');
 const { defaults } = require('jest-config');
+const tsconfig = require('../tsconfig.json');
+
+const moduleNameMapperFromTSPaths = fromPairs(
+  Object.entries(tsconfig.compilerOptions.paths).map(([alias, [aliasedPath]]) => [
+    `^${alias.replace(/\*/, '(.*)')}`,
+    `<rootDir>/${aliasedPath.replace(/\*/, '$1')}`,
+  ])
+);
 
 module.exports = {
   rootDir: '../',
@@ -7,7 +16,5 @@ module.exports = {
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'ts', 'tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest/setup.ts'],
   verbose: true,
-  moduleNameMapper: {
-    'test-utils': '<rootDir>/jest/utils',
-  },
+  moduleNameMapper: moduleNameMapperFromTSPaths,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,6 +2551,34 @@
         }
       }
     },
+    "@jfonx/console-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jfonx/console-utils/-/console-utils-1.0.3.tgz",
+      "integrity": "sha512-/XbnqjWc7yNZVLAJJO9rimfIz9DYte+cj3EF9hwhIv7vw6ok2t3cjl0huYsmD89srKH03vWjeqAcIH86CuYj3g==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.3.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        }
+      }
+    },
+    "@jfonx/file-utils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@jfonx/file-utils/-/file-utils-3.0.1.tgz",
+      "integrity": "sha512-qwH0CuzWmghtTHGMyuPHj6SJPQgWeiXFJBfrxCWMbzxVCa3aLZPEfzSdlSnC/UABsk6feRkNdHXw59rVshNPqw==",
+      "dev": true,
+      "requires": {
+        "@jfonx/console-utils": "^1.0.3",
+        "comment-json": "^4.1.0",
+        "find-up": "^4.1.0"
+      }
+    },
     "@juggle/resize-observer": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
@@ -4553,6 +4581,12 @@
         "is-string": "^1.0.5"
       }
     },
+    "array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -5993,6 +6027,19 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
+    "comment-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
+      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "dev": true,
+      "requires": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
     "common-dir": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/common-dir/-/common-dir-3.0.1.tgz",
@@ -6863,6 +6910,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-newline": {
@@ -7977,6 +8030,15 @@
         }
       }
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "expect": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-26.2.0.tgz",
@@ -8387,6 +8449,16 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-node-modules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
+      "integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^4.0.0",
+        "merge": "^2.1.0"
+      }
+    },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -8417,6 +8489,69 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
+        }
+      }
+    },
+    "findup-sync": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+      "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
     },
@@ -8915,6 +9050,12 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
@@ -9016,6 +9157,15 @@
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -12546,6 +12696,12 @@
         }
       }
     },
+    "merge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -13578,6 +13734,12 @@
         "json-parse-better-errors": "^1.0.1",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "5.1.1",
@@ -14967,6 +15129,51 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
+        }
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "dependencies": {
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -16613,6 +16820,160 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
+    },
+    "tsc-alias": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.3.5.tgz",
+      "integrity": "sha512-N3uubBSc5yctV4RXj2Yxye28plmvs2QMqH5P2p0mpFrnt3y6PHg30YJZlPYP3rwrlAdUrzDmcqRB64IjxGVJTw==",
+      "dev": true,
+      "requires": {
+        "@jfonx/console-utils": "^1.0.3",
+        "@jfonx/file-utils": "^3.0.1",
+        "chokidar": "^3.5.0",
+        "commander": "^6.2.1",
+        "find-node-modules": "^2.1.0",
+        "globby": "^11.0.2",
+        "normalize-path": "^3.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
+          }
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "test": "jest --config jest/config.js",
     "test:watch": "npm run test -- --watch",
     "prepare": "npm run build",
-    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel src -d dist/cjs --extensions '.ts,.tsx' --ignore '**/*.test.tsx','**/*.test.ts' && tsc --emitDeclarationOnly --declarationDir dist/cjs -p .",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel src -d dist/esm --extensions '.ts,.tsx' --ignore '**/*.test.tsx','**/*.test.ts' && tsc --emitDeclarationOnly --declarationDir dist/esm -p .",
+    "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel src -d dist/cjs --extensions '.ts,.tsx' --ignore '**/*.test.tsx','**/*.test.ts' && tsc --emitDeclarationOnly --declarationDir dist/cjs -p . && tsc-alias --dir=dist/cjs",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel src -d dist/esm --extensions '.ts,.tsx' --ignore '**/*.test.tsx','**/*.test.ts' && tsc --emitDeclarationOnly --declarationDir dist/esm -p . && tsc-alias --dir=dist/esm",
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "docs": "npx styleguidist build",
     "lint": "eslint --fix \"src/**/*.{ts,tsx}\" && prettier --write \"src/**/*.{ts,tsx,md,mdx,json}\"",
@@ -121,6 +121,7 @@
     "react-dom": "^16.11.0",
     "react-styleguidist": "^11.1.7",
     "rimraf": "^2.6.3",
+    "tsc-alias": "^1.3.5",
     "typescript": "^3.9.5",
     "webpack": "^4.42.1"
   }

--- a/src/components/AbstractButton/AbstractButton.tsx
+++ b/src/components/AbstractButton/AbstractButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { pounce } from '../../system';
-import { __DEV__ } from '../../utils/helpers';
+import { pounce } from 'system';
+import { __DEV__ } from 'utils/helpers';
 
 export type AbstractButtonProps = React.ComponentProps<typeof AbstractButton>;
 

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import ControlledAlert, { ControlledAlertProps } from '../utils/ControlledAlert';
-import Collapse from '../Collapse';
+import ControlledAlert, { ControlledAlertProps } from 'components/utils/ControlledAlert';
+import Collapse from 'components/Collapse';
 
 export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & { onClose?: () => void };
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Theme } from '../../theme';
+import { Theme } from 'theme';
 import useBadgeStyles from './useBadgeStyles';
-import Box from '../Box';
+import Box from 'components/Box';
 
 export interface BadgeProps {
   /** The color theme of the badge */

--- a/src/components/Badge/useBadgeStyles.tsx
+++ b/src/components/Badge/useBadgeStyles.tsx
@@ -1,5 +1,5 @@
 import { BadgeProps } from './Badge';
-import { FlexProps } from '../Flex';
+import { FlexProps } from 'components/Flex';
 
 type UseBadgeStylesProps = Pick<BadgeProps, 'variant' | 'color'>;
 type UseBadgeStylesPayload = Partial<FlexProps>;

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { pounce, NativeAttributes, PounceComponentProps } from '../../system';
-import { __DEV__ } from '../../utils/helpers';
+import { pounce, NativeAttributes, PounceComponentProps } from 'system';
+import { __DEV__ } from 'utils/helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type BoxProps<T extends React.ElementType = any> = PounceComponentProps<T>;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Flex from '../Flex';
-import Icon from '../Icon';
-import Box from '../Box';
-import Link, { LinkProps } from '../Link';
+import Flex from 'components/Flex';
+import Icon from 'components/Icon';
+import Box from 'components/Box';
+import Link, { LinkProps } from 'components/Link';
 
 export interface BreadcrumbItem {
   /** The URL that this Breadcrumbs should navigate to when clicked */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import AbstractButton from '../AbstractButton';
-import { BoxProps, NativeAttributes } from '../Box';
+import AbstractButton from 'components/AbstractButton';
+import { BoxProps, NativeAttributes } from 'components/Box';
 import useButtonStyles from './useButtonStyles';
-import Spinner from '../Spinner';
-import Icon, { IconProps } from '../Icon';
+import Spinner from 'components/Spinner';
+import Icon, { IconProps } from 'components/Icon';
 
 export interface ButtonProps extends NativeAttributes<'button'>, Pick<BoxProps, 'as' | 'to'> {
   /** The size (height) of the button */

--- a/src/components/Button/useButtonStyles.tsx
+++ b/src/components/Button/useButtonStyles.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { AbstractButtonProps } from '../AbstractButton';
+import { AbstractButtonProps } from 'components/AbstractButton';
 import { ButtonProps } from './Button';
-import { Theme } from '../../theme';
-import { lightenDarkenColor } from '../../utils/helpers';
-import useTheme from '../../utils/useTheme';
+import { Theme } from 'theme';
+import { lightenDarkenColor } from 'utils/helpers';
+import useTheme from 'utils/useTheme';
 
 type ThemeColor = keyof Theme['colors'];
 type ButtonColorVariant = ButtonProps['variantColor'];

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 export type CardProps = Omit<BoxProps, 'bg' | 'background' | 'backgroundColor' | 'borderRadius'> & {
   /** Whether the card should be light blue-navy or dark blue-navy */

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
+import Box, { NativeAttributes } from 'components/Box';
 import useCheckboxStyles from './useCheckboxStyles';
 
 export type CheckboxProps = NativeAttributes<'input'> & {

--- a/src/components/Checkbox/useCheckboxStyles.tsx
+++ b/src/components/Checkbox/useCheckboxStyles.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { BoxProps } from '../Box';
-import { addOpacity } from '../../utils/helpers';
+import { BoxProps } from 'components/Box';
+import { addOpacity } from 'utils/helpers';
 import { CheckboxProps } from './Checkbox';
-import useTheme from '../../utils/useTheme';
+import useTheme from 'utils/useTheme';
 
 type UseCheckboxStyles = Pick<CheckboxProps, 'invalid' | 'checked' | 'indeterminate'>;
 

--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useMeasure from 'react-use-measure';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { animated, useTransition } from 'react-spring';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 const AnimatedBox = animated(Box);
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -2,13 +2,13 @@
 import React from 'react';
 import Downshift from 'downshift';
 import { filter as fuzzySearch } from 'fuzzaldrin';
-import Box from '../Box';
-import Flex from '../Flex';
-import IconButton from '../IconButton';
-import { InputControl, InputElement, InputLabel, InputElementProps } from '../utils/Input';
-import { typedMemo } from '../../utils/helpers';
-import Menu from '../utils/Menu';
-import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
+import Box from 'components/Box';
+import Flex from 'components/Flex';
+import IconButton from 'components/IconButton';
+import { InputControl, InputElement, InputLabel, InputElementProps } from 'components/utils/Input';
+import { typedMemo } from 'utils/helpers';
+import Menu from 'components/utils/Menu';
+import ComboBoxItems from 'components/utils/ComboboxItems';
 
 export type ComboboxProps<T> = {
   /** Callback when the selection changes */

--- a/src/components/DateInput/Cell.tsx
+++ b/src/components/DateInput/Cell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
-import useTheme from '../../utils/useTheme';
-import { addOpacity } from '../../utils/helpers';
+import useTheme from 'utils/useTheme';
+import { addOpacity } from 'utils/helpers';
 
 const Cell: React.FC<BoxProps> = props => {
   const theme = useTheme();

--- a/src/components/DateInput/ClearButton.tsx
+++ b/src/components/DateInput/ClearButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AbstractButton, { AbstractButtonProps } from '../AbstractButton';
+import AbstractButton, { AbstractButtonProps } from 'components/AbstractButton';
 
 const TextButton: React.FC<AbstractButtonProps> = props => {
   return (

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -1,19 +1,19 @@
 import React, { useState, useCallback } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import Box from '../Box';
-import Flex from '../Flex';
-import Button from '../Button';
+import Box from 'components/Box';
+import Flex from 'components/Flex';
+import Button from 'components/Button';
 import Month from './Month';
-import { IconButton } from '../../index';
+import IconButton from 'components/IconButton';
 import DateWrapper from './DateWrapper';
-import TextInput, { TextInputProps } from '../TextInput';
+import TextInput, { TextInputProps } from 'components/TextInput';
 import TimePicker from './TimePicker';
 import ClearButton from './ClearButton';
-import { noop, dateToDayjs, now } from '../../utils/helpers';
-import useDisclosure from '../../utils/useDisclosure';
-import useEscapeKey from '../../utils/useEscapeKey';
-import usePrevious from '../../utils/usePrevious';
-import useOutsideClick from '../../utils/useOutsideClick';
+import { noop, dateToDayjs, now } from 'utils/helpers';
+import useDisclosure from 'utils/useDisclosure';
+import useEscapeKey from 'utils/useEscapeKey';
+import usePrevious from 'utils/usePrevious';
+import useOutsideClick from 'utils/useOutsideClick';
 
 export interface DateInputProps {
   /**

--- a/src/components/DateInput/DateWrapper.tsx
+++ b/src/components/DateInput/DateWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Card from '../Card';
+import Card from 'components/Card';
 import { useTransition, animated } from 'react-spring';
-import useDropdownAlignment from '../Dropdown/useDropdownAlignment';
+import useDropdownAlignment from 'components/Dropdown/useDropdownAlignment';
 import Popover from '@reach/popover';
 
 interface DateWrapperProps {

--- a/src/components/DateInput/Day.tsx
+++ b/src/components/DateInput/Day.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Box from '../Box';
-import AbstractButton from '../AbstractButton';
+import Box from 'components/Box';
+import AbstractButton from 'components/AbstractButton';
 import Cell from './Cell';
 import { Dayjs } from 'dayjs';
-import { noop, now } from '../../utils/helpers';
+import { noop, now } from 'utils/helpers';
 
 export interface DayProps {
   day?: number;

--- a/src/components/DateInput/Month.tsx
+++ b/src/components/DateInput/Month.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import chunk from 'lodash/chunk';
-import Flex from '../Flex';
-import Box from '../Box';
+import Flex from 'components/Flex';
+import Box from 'components/Box';
 import Day from './Day';
-import { noop } from '../../utils/helpers';
+import { noop } from 'utils/helpers';
 export interface MonthProps {
   year: number;
   month: number;

--- a/src/components/DateInput/TimePicker.tsx
+++ b/src/components/DateInput/TimePicker.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Dayjs } from 'dayjs';
-import Box from '../Box';
-import Combobox from '../Combobox';
-import { now, slugify } from '../../utils/helpers';
-import Flex from '../Flex';
+import Box from 'components/Box';
+import Combobox from 'components/Combobox';
+import { now, slugify } from 'utils/helpers';
+import Flex from 'components/Flex';
 
 const getHourItems = (mode: string) => {
   const limit = mode === '12h' ? 12 : 24;

--- a/src/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/components/DateRangeInput/DateRangeInput.tsx
@@ -1,21 +1,21 @@
 import React, { useState, useCallback } from 'react';
 import { Dayjs } from 'dayjs';
-import IconButton from '../IconButton';
-import Box from '../Box';
+import IconButton from 'components/IconButton';
+import Box from 'components/Box';
 import Presets from './Presets';
-import Flex from '../Flex';
-import Button from '../Button';
+import Flex from 'components/Flex';
+import Button from 'components/Button';
 import DoubleTextInput from './DoubleTextInput';
-import DateWrapper from '../DateInput/DateWrapper';
-import TimePicker from '../DateInput/TimePicker';
-import Month from '../DateInput/Month';
-import ClearButton from '../DateInput/ClearButton';
-import { TextInputProps } from '../TextInput';
-import { dateToDayjs, noop, now } from '../../utils/helpers';
-import useEscapeKey from '../../utils/useEscapeKey';
-import usePrevious from '../../utils/usePrevious';
-import useOutsideClick from '../../utils/useOutsideClick';
-import useDisclosure from '../../utils/useDisclosure';
+import DateWrapper from 'components/DateInput/DateWrapper';
+import TimePicker from 'components/DateInput/TimePicker';
+import Month from 'components/DateInput/Month';
+import ClearButton from 'components/DateInput/ClearButton';
+import { TextInputProps } from 'components/TextInput';
+import { dateToDayjs, noop, now } from 'utils/helpers';
+import useEscapeKey from 'utils/useEscapeKey';
+import usePrevious from 'utils/usePrevious';
+import useOutsideClick from 'utils/useOutsideClick';
+import useDisclosure from 'utils/useDisclosure';
 
 export interface DateRangeInputProps {
   /**

--- a/src/components/DateRangeInput/DoubleTextInput.tsx
+++ b/src/components/DateRangeInput/DoubleTextInput.tsx
@@ -1,10 +1,10 @@
 import React, { ChangeEventHandler } from 'react';
-import Box from '../Box';
-import Flex from '../Flex';
-import { slugify } from '../../utils/helpers';
-import { TextInputProps } from '../TextInput';
-import { InputControl, InputElement, InputLabel } from '../utils/Input';
-import { noop } from '../../utils/helpers';
+import Box from 'components/Box';
+import Flex from 'components/Flex';
+import { slugify } from 'utils/helpers';
+import { TextInputProps } from 'components/TextInput';
+import { InputControl, InputElement, InputLabel } from 'components/utils/Input';
+import { noop } from 'utils/helpers';
 
 export type DoubleTextInputProps = Omit<TextInputProps, 'label' | 'placeholder'> & {
   /** The `from` label for the double text input*/

--- a/src/components/DateRangeInput/Presets.tsx
+++ b/src/components/DateRangeInput/Presets.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Dayjs } from 'dayjs';
-import { getDates } from '../../utils/helpers';
-import Box from '../Box';
-import AbstractButton from '../AbstractButton';
+import { getDates } from 'utils/helpers';
+import Box from 'components/Box';
+import AbstractButton from 'components/AbstractButton';
 
 type OnSelectCallback = (date: [Dayjs, Dayjs]) => void;
 type OnCurrentMonthSelect = React.Dispatch<React.SetStateAction<Dayjs>>;

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 export interface DividerProps extends BoxProps {
   /** The direction of the divider */

--- a/src/components/Dropdown/DropdownButton.tsx
+++ b/src/components/Dropdown/DropdownButton.tsx
@@ -1,6 +1,6 @@
 import { MenuButton as ReachMenuButton } from '@reach/menu-button';
 import type * as Polymorphic from '@reach/utils/polymorphic';
-import { NativeAttributes } from '../Box';
+import { NativeAttributes } from 'components/Box';
 
 export type DropdownButtonProps = NativeAttributes<'button'>;
 export const DropdownButton = ReachMenuButton as Polymorphic.ForwardRefComponent<

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MenuItem as ReachMenuItem, MenuLinkProps as ReachMenuLinkProps } from '@reach/menu-button';
 import type * as Polymorphic from '@reach/utils/polymorphic';
-import MenuItem from '../utils/MenuItem/MenuItem';
+import MenuItem from 'components/utils/MenuItem';
 
 export type DropdownItemProps = ReachMenuLinkProps; // this is not a typo, it's intentional
 

--- a/src/components/Dropdown/DropdownLink.tsx
+++ b/src/components/Dropdown/DropdownLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MenuLink as ReachMenuLink, MenuLinkProps as ReachMenuLinkProps } from '@reach/menu-button';
 import type * as Polymorphic from '@reach/utils/polymorphic';
-import MenuItem from '../utils/MenuItem/MenuItem';
+import MenuItem from 'components/utils/MenuItem';
 
 export type DropdownLinkProps = ReachMenuLinkProps;
 

--- a/src/components/Dropdown/DropdownMenu.tsx
+++ b/src/components/Dropdown/DropdownMenu.tsx
@@ -6,7 +6,7 @@ import {
   useMenuButtonContext as useDropdownContext,
 } from '@reach/menu-button';
 import { useTransition, animated } from 'react-spring';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 const AnimatedPopover = animated(ReachMenuPopover);
 

--- a/src/components/FadeIn/FadeIn.tsx
+++ b/src/components/FadeIn/FadeIn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 import { generateKeyframes } from './utils';
 
 export interface FadeInProps extends Pick<BoxProps, 'as'> {

--- a/src/components/Flex/Flex.test.tsx
+++ b/src/components/Flex/Flex.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'test-utils';
 import Flex from './Flex';
-import Box from '../Box';
+import Box from 'components/Box';
 
 describe('Flex', () => {
   it('renders', async () => {

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 import { useItemSpacingProps } from './utils';
 
 export type FlexProps = Omit<BoxProps, 'display'> & {

--- a/src/components/FormError/FormError.tsx
+++ b/src/components/FormError/FormError.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Icon from '../Icon';
-import Text, { TextProps } from '../Text';
+import Icon from 'components/Icon';
+import Text, { TextProps } from 'components/Text';
 
 export type FormErrorProps = TextProps;
 

--- a/src/components/FormHelperText/FormHelperText.tsx
+++ b/src/components/FormHelperText/FormHelperText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Text, { TextProps } from '../Text';
+import Text, { TextProps } from 'components/Text';
 
 export interface FormHelperTextProps extends TextProps {
   id: string; // we require `id` to remind people to associate it with an `aria-describedby`

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 export type GridProps = Omit<BoxProps, 'display'> & {
   /** An alias for the `gridTemplateColumns` property */

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 import useHeadingStyles from './useHeadingStyles';
 
 export interface HeadingProps extends BoxProps<'h1'> {

--- a/src/components/Heading/useHeadingStyles.tsx
+++ b/src/components/Heading/useHeadingStyles.tsx
@@ -1,4 +1,4 @@
-import { BoxProps } from '../Box';
+import { BoxProps } from 'components/Box';
 import { HeadingProps } from './Heading';
 
 type UseHeadingStyles = Pick<HeadingProps, 'size'>;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
-import useTheme from '../../utils/useTheme';
-import { Theme } from '../../theme';
+import Box, { BoxProps } from 'components/Box';
+import useTheme from 'utils/useTheme';
+import { Theme } from 'theme';
 
 export interface IconProps extends BoxProps<'svg'> {
   /** The icon that you want to show */

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Icon, { IconProps } from '../Icon';
+import Icon, { IconProps } from 'components/Icon';
 import useIconButtonStyles from './useIconButtonStyles';
-import { BoxProps, NativeAttributes } from '../Box';
-import AbstractButton from '../AbstractButton';
+import { BoxProps, NativeAttributes } from 'components/Box';
+import AbstractButton from 'components/AbstractButton';
 
 export interface IconButtonProps extends NativeAttributes<'button'>, Pick<BoxProps, 'as' | 'to'> {
   /** The size of the icon button */

--- a/src/components/IconButton/useIconButtonStyles.tsx
+++ b/src/components/IconButton/useIconButtonStyles.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { addOpacity, lightenDarkenColor } from '../../utils/helpers';
-import { AbstractButtonProps } from '../AbstractButton';
-import { getThemeColor } from '../Button/useButtonStyles';
-import useTheme from '../../utils/useTheme';
+import { addOpacity, lightenDarkenColor } from 'utils/helpers';
+import { AbstractButtonProps } from 'components/AbstractButton';
+import { getThemeColor } from 'components/Button/useButtonStyles';
+import useTheme from 'utils/useTheme';
 import { IconButtonProps } from './IconButton';
-import { Theme } from '../../theme';
-import { ButtonProps } from '../Button';
+import { Theme } from 'theme';
+import { ButtonProps } from 'components/Button';
 
 type ButtonColorVariant = ButtonProps['variantColor'];
 type UseIconButtonStyles = Required<

--- a/src/components/Img/Img.tsx
+++ b/src/components/Img/Img.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 
 export interface ImgProps extends BoxProps<'img'> {
   /** The image URL */

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps } from '../Box';
+import Box, { BoxProps } from 'components/Box';
 import useLinkStyles from './useLinkStyles';
 
 export interface LinkProps extends Omit<BoxProps<'a'>, 'color'> {

--- a/src/components/Link/useLinkStyles.tsx
+++ b/src/components/Link/useLinkStyles.tsx
@@ -1,5 +1,5 @@
 import { LinkProps } from './Link';
-import { BoxProps } from '../Box';
+import { BoxProps } from 'components/Box';
 
 type UseLinkStyles = Pick<LinkProps, 'variant'>;
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { animated, useTransition } from 'react-spring';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 import { useId } from '@reach/auto-id';
-import Box from '../Box';
-import Card from '../Card';
-import Heading from '../Heading';
-import Flex from '../Flex';
-import IconButton from '../IconButton';
+import Box from 'components/Box';
+import Card from 'components/Card';
+import Heading from 'components/Heading';
+import Flex from 'components/Flex';
+import IconButton from 'components/IconButton';
 
 const AnimatedDialogOverlay = animated(DialogOverlay);
 const AnimatedDialogContent = animated(DialogContent);

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -2,15 +2,15 @@
 import React from 'react';
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import { filter as fuzzySearch } from 'fuzzaldrin';
-import Box from '../Box';
-import IconButton from '../IconButton';
-import Flex from '../Flex';
-import { InputControl, InputLabel, InputElement, InputElementProps } from '../utils/Input';
+import Box from 'components/Box';
+import IconButton from 'components/IconButton';
+import Flex from 'components/Flex';
+import { InputControl, InputLabel, InputElement, InputElementProps } from 'components/utils/Input';
 import Tag from './Tag';
-import { typedMemo } from '../../utils/helpers';
-import Menu from '../utils/Menu';
-import AbstractButton from '../AbstractButton';
-import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
+import { typedMemo } from 'utils/helpers';
+import Menu from 'components/utils/Menu';
+import AbstractButton from 'components/AbstractButton';
+import ComboBoxItems from 'components/utils/ComboboxItems';
 
 export type MultiComboboxProps<T> = {
   /** Callback when the selection changes */

--- a/src/components/MultiCombobox/Tag.tsx
+++ b/src/components/MultiCombobox/Tag.tsx
@@ -1,7 +1,7 @@
-import Icon from '../Icon';
+import Icon from 'components/Icon';
 import React from 'react';
-import AbstractButton from '../AbstractButton';
-import Flex, { FlexProps } from '../Flex';
+import AbstractButton from 'components/AbstractButton';
+import Flex, { FlexProps } from 'components/Flex';
 
 export interface TagProps extends FlexProps {
   /**

--- a/src/components/NumberInput/NumberInput.tsx
+++ b/src/components/NumberInput/NumberInput.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { NativeAttributes } from '../Box';
-import { slugify, noop, isEmptyValue } from '../../utils/helpers';
-import { typedMemo } from '../../utils/helpers';
-import { InputControl, InputElement, InputLabel } from '../utils/Input';
-import AbstractButton from '../AbstractButton';
-import Icon from '../Icon';
-import Flex from '../Flex';
+import { NativeAttributes } from 'components/Box';
+import { slugify, noop, isEmptyValue } from 'utils/helpers';
+import { typedMemo } from 'utils/helpers';
+import { InputControl, InputElement, InputLabel } from 'components/utils/Input';
+import AbstractButton from 'components/AbstractButton';
+import Icon from 'components/Icon';
+import Flex from 'components/Flex';
 
 export type NumberInputProps = NativeAttributes<'input'> & {
   /** Callback when the number changes */

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -9,8 +9,8 @@ import {
 import Popover from './Popover';
 import PopoverTrigger from './PopoverTrigger';
 import PopoverMenu from './PopoverContent';
-import Button from '../Button';
-import Text from '../Text';
+import Button from 'components/Button';
+import Text from 'components/Text';
 
 describe('Popover', () => {
   it('matches snapshot when closed', () => {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useDisclosure from '../../utils/useDisclosure';
+import useDisclosure from 'utils/useDisclosure';
 import { useId } from '@reach/auto-id';
 
 interface PopoverContext {

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -4,9 +4,9 @@ import { useComposedRefs } from '@reach/utils';
 import { animated, useTransition } from 'react-spring';
 import { usePopoverContext } from './Popover';
 import usePopoverContentAlignment from './usePopoverContentAlignment';
-import useOutsideClick from '../../utils/useOutsideClick';
-import useEscapeKey from '../../utils/useEscapeKey';
-import Box from '../Box';
+import useOutsideClick from 'utils/useOutsideClick';
+import useEscapeKey from 'utils/useEscapeKey';
+import Box from 'components/Box';
 
 const AnimatedPopover = animated(ReachUIPopover);
 

--- a/src/components/Popover/PopoverTrigger.tsx
+++ b/src/components/Popover/PopoverTrigger.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useComposedRefs, composeEventHandlers } from '@reach/utils';
 import type * as Polymorphic from '@reach/utils/polymorphic';
-import { NativeAttributes } from '../../system';
+import { NativeAttributes } from 'system';
 import { usePopoverContext } from './Popover';
 
 export type PopoverTriggerProps = NativeAttributes<'button'>;

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Box from '../Box';
-import { Theme } from '../../theme';
+import Box from 'components/Box';
+import { Theme } from 'theme';
 
 export interface ProgressBarProps {
   /** The thickness (in pixels) of the progress bar (a.k.a. vertical height). Defaults to `5` */

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
+import Box, { NativeAttributes } from 'components/Box';
 import useRadioStyles from './useRadioStyles';
 
 export type RadioProps = NativeAttributes<'input'> & {

--- a/src/components/Radio/useRadioStyles.tsx
+++ b/src/components/Radio/useRadioStyles.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { BoxProps } from '../Box';
-import { addOpacity } from '../../utils/helpers';
+import { BoxProps } from 'components/Box';
+import { addOpacity } from 'utils/helpers';
 import { RadioProps } from './Radio';
-import useTheme from '../../utils/useTheme';
+import useTheme from 'utils/useTheme';
 
 type UseRadioStyles = Pick<RadioProps, 'invalid' | 'checked'>;
 

--- a/src/components/SideSheet/SideSheet.tsx
+++ b/src/components/SideSheet/SideSheet.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { animated, useTransition } from 'react-spring';
-import Box from '../Box';
-import IconButton from '../IconButton';
+import Box from 'components/Box';
+import IconButton from 'components/IconButton';
 import { DialogContent, DialogOverlay } from '@reach/dialog';
 
 const AnimatedDialogOverlay = animated(DialogOverlay);

--- a/src/components/SimpleGrid/SimpleGrid.tsx
+++ b/src/components/SimpleGrid/SimpleGrid.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as StyledSystem from 'styled-system';
-import Grid, { GridProps } from '../Grid';
+import Grid, { GridProps } from 'components/Grid';
 import { countToColumns, widthToColumns } from './utils';
 
 export interface SimpleGridProps extends GridProps {

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ControlledAlert, { ControlledAlertProps } from '../utils/ControlledAlert';
+import ControlledAlert, { ControlledAlertProps } from 'components/utils/ControlledAlert';
 
 export interface SnackbarProps extends Omit<ControlledAlertProps, 'open' | 'onClose'> {
   /** The number of milliseconds that this snackbar will show until it automatically disappears

--- a/src/components/Snackbar/SnackbarContext.tsx
+++ b/src/components/Snackbar/SnackbarContext.tsx
@@ -3,10 +3,10 @@ import ReactDOM from 'react-dom';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { animated, useTransition } from 'react-spring';
 import useMeasure from 'react-use-measure';
-import Flex from '../Flex';
-import Snackbar, { SnackbarProps } from '../Snackbar';
-import { isBrowser } from '../../utils/helpers';
-import Box from '../Box';
+import Flex from 'components/Flex';
+import Snackbar, { SnackbarProps } from 'components/Snackbar';
+import { isBrowser } from 'utils/helpers';
+import Box from 'components/Box';
 
 type SnackbarContextValue = {
   pushSnackbar: (props: SnackbarPublicProps) => string;

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/react';
-import Box, { BoxProps } from '../Box';
-import { Theme } from '../../theme';
+import Box, { BoxProps } from 'components/Box';
+import { Theme } from 'theme';
 
 export interface SpinnerProps extends BoxProps<'svg'> {
   /** Delay after which spinner should be visible. */

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
-import Flex from '../Flex';
+import Box, { NativeAttributes } from 'components/Box';
+import Flex from 'components/Flex';
 
 export type SwitchProps = NativeAttributes<'input'> & {
   /** Whether the checkbox is currently disabled */

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps, NativeAttributes } from '../Box';
+import Box, { BoxProps, NativeAttributes } from 'components/Box';
 
 export interface TableProps extends NativeAttributes<'table'> {
   /** The table layout. Defaults to `auto` */

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
+import Box, { NativeAttributes } from 'components/Box';
 
 export type TableBodyProps = NativeAttributes<'tbody'>;
 

--- a/src/components/Table/TableCell.tsx
+++ b/src/components/Table/TableCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps, NativeAttributes } from '../Box';
+import Box, { BoxProps, NativeAttributes } from 'components/Box';
 import { useTable } from './Table';
 
 export type TableCellProps = Pick<BoxProps, 'truncated' | 'color' | 'width' | 'maxWidth'> &

--- a/src/components/Table/TableHead.tsx
+++ b/src/components/Table/TableHead.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
+import Box, { NativeAttributes } from 'components/Box';
 
 export type TableHeadProps = NativeAttributes<'thead'>;
 

--- a/src/components/Table/TableHeaderCell.tsx
+++ b/src/components/Table/TableHeaderCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { BoxProps, NativeAttributes } from '../Box';
+import Box, { BoxProps, NativeAttributes } from 'components/Box';
 import { useTable } from './Table';
 
 export type TableHeaderCellProps = NativeAttributes<'th'> & {

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
+import Box, { NativeAttributes } from 'components/Box';
 import { useTable } from './Table';
 
 export interface TableRowProps extends NativeAttributes<'tr'> {

--- a/src/components/Table/TableSortableHeaderCell.tsx
+++ b/src/components/Table/TableSortableHeaderCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Flex from '../Flex';
-import Box from '../Box';
-import Icon from '../Icon';
+import Flex from 'components/Flex';
+import Box from 'components/Box';
+import Icon from 'components/Icon';
 import TableHeaderCell, { TableHeaderCellProps } from './TableHeaderCell';
 
 const sortableHoverStyle = {

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Tab as ReachTab } from '@reach/tabs';
 import type * as Polymorphic from '@reach/utils/polymorphic';
-import AbstractButton from '../AbstractButton';
-import { NativeAttributes } from '../Box';
+import AbstractButton from 'components/AbstractButton';
+import { NativeAttributes } from 'components/Box';
 
 type TabRenderProps = {
   /** Whether the tab is selected */

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TabList as ReachTabList, useTabsContext } from '@reach/tabs';
-import { NativeAttributes } from '../Box';
-import Flex from '../Flex';
+import { NativeAttributes } from 'components/Box';
+import Flex from 'components/Flex';
 
 export type TabListProps = NativeAttributes<'div'>;
 

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TabPanel as ReachTabPanel, useTabsContext } from '@reach/tabs';
-import Box from '../Box';
+import Box from 'components/Box';
 
 type TabPanelProps = {
   /**

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,5 +1,5 @@
-import { __DEV__ } from '../../utils/helpers';
-import { pounce } from '../../system';
+import { __DEV__ } from 'utils/helpers';
+import { pounce } from 'system';
 
 export type TextProps = React.ComponentProps<typeof Text>;
 

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
-import { NativeAttributes } from '../Box';
-import { InputControl, InputElement, InputLabel } from '../utils/Input';
-import { slugify } from '../../utils/helpers';
+import { NativeAttributes } from 'components/Box';
+import { InputControl, InputElement, InputLabel } from 'components/utils/Input';
+import { slugify } from 'utils/helpers';
 
 export type TextAreaProps = NativeAttributes<'textarea'> & {
   /** The label that is associated with this textaera */

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Box, { NativeAttributes } from '../Box';
-import { slugify, isEmptyValue } from '../../utils/helpers';
-import { InputControl, InputElement, InputLabel } from '../utils/Input';
-import Icon, { IconProps } from '../Icon';
-import Flex from '../Flex';
+import Box, { NativeAttributes } from 'components/Box';
+import { slugify, isEmptyValue } from 'utils/helpers';
+import { InputControl, InputElement, InputLabel } from 'components/utils/Input';
+import Icon, { IconProps } from 'components/Icon';
+import Flex from 'components/Flex';
 
 export type TextIconProps = {
   color?: IconProps['color'];

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTooltip, TooltipPopup } from '@reach/tooltip';
 import { useTransition, animated } from 'react-spring';
 import { positionRight } from './utils';
-import Box from '../Box';
+import Box from 'components/Box';
 
 const AnimatedTooltipPopup = animated(TooltipPopup);
 

--- a/src/components/utils/ComboboxItems/ComboboxItems.tsx
+++ b/src/components/utils/ComboboxItems/ComboboxItems.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { GetItemPropsOptions } from 'downshift';
 import groupBy from 'lodash/groupBy';
-import Box from '../../Box';
-import MenuItem from '../MenuItem';
+import Box from 'components/Box';
+import MenuItem from 'components/utils/MenuItem';
 
-interface ComboBoxItemsProps<T> {
+interface ComboboxItemsProps<T> {
   items: T[];
   disableItem: (item: T) => boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,7 +20,7 @@ interface ComboBoxItemsProps<T> {
  * Acts as a wrapper of MenuItems in a list of dropdown options,
  * to allow grouping.
  */
-function ComboBoxItems<Item>({
+function ComboboxItems<Item>({
   items,
   itemToGroup,
   getItemProps,
@@ -28,7 +28,7 @@ function ComboBoxItems<Item>({
   disableItem,
   selectedItems,
   allowMultipleSelection,
-}: ComboBoxItemsProps<Item>): React.ReactElement<ComboBoxItemsProps<Item>> {
+}: ComboboxItemsProps<Item>): React.ReactElement<ComboboxItemsProps<Item>> {
   const groupedItems = React.useMemo(() => {
     return groupBy(items, itemToGroup);
   }, [items, itemToGroup]);
@@ -112,4 +112,4 @@ function ComboBoxItems<Item>({
   );
 }
 
-export default ComboBoxItems;
+export default ComboboxItems;

--- a/src/components/utils/ComboboxItems/index.tsx
+++ b/src/components/utils/ComboboxItems/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ComboboxItems';

--- a/src/components/utils/ControlledAlert/ControlledAlert.tsx
+++ b/src/components/utils/ControlledAlert/ControlledAlert.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useId } from '@reach/auto-id';
-import Box from '../../Box';
-import Flex from '../../Flex';
-import IconButton from '../../IconButton';
-import Icon from '../../Icon';
+import Box from 'components/Box';
+import Flex from 'components/Flex';
+import IconButton from 'components/IconButton';
+import Icon from 'components/Icon';
 import useAlertStyles from './useAlertStyles';
 
 export interface ControlledAlertProps {

--- a/src/components/utils/Input/InputControl.tsx
+++ b/src/components/utils/Input/InputControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Box from '../../Box';
+import Box from 'components/Box';
 import { InputContext } from './InputContext';
 
 export type InputControlProps = {

--- a/src/components/utils/Input/InputElement.tsx
+++ b/src/components/utils/Input/InputElement.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useInputContext } from './InputContext';
-import { NativeAttributes } from '../../Box';
-import Box, { BoxProps } from '../../Box';
-import useTheme from '../../../utils/useTheme';
+import { NativeAttributes } from 'components/Box';
+import Box, { BoxProps } from 'components/Box';
+import useTheme from 'utils/useTheme';
 
 type StandaloneInputElementProps = {
   /**

--- a/src/components/utils/Input/InputLabel.tsx
+++ b/src/components/utils/Input/InputLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useInputContext } from './InputContext';
-import Box, { BoxProps, NativeAttributes } from '../../Box';
+import Box, { BoxProps, NativeAttributes } from 'components/Box';
 
 export type InputLabelProps = NativeAttributes<'label'> &
   Pick<BoxProps, 'visuallyHidden' | 'left'> & {

--- a/src/components/utils/Menu/Menu.tsx
+++ b/src/components/utils/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTransition, animated } from 'react-spring';
-import Box from '../../Box';
+import Box from 'components/Box';
 
 const AnimatedBox = animated(Box);
 

--- a/src/components/utils/MenuItem/MenuItem.tsx
+++ b/src/components/utils/MenuItem/MenuItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Theme } from '../../../theme';
-import Box, { NativeAttributes } from '../../Box';
+import { Theme } from 'theme';
+import Box, { NativeAttributes } from 'components/Box';
 
 interface MenuItemProps extends NativeAttributes<'div'> {
   /** Whether the current item is currently selected **/

--- a/src/system/system.ts
+++ b/src/system/system.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as StyledSystem from 'styled-system';
 import * as H from 'history';
-import { Theme } from '../theme';
+import { Theme } from 'theme';
 import { UtilityProps } from './utility';
 import { PseudoProps } from './pseudo';
 

--- a/src/utils/GlobalStyles.tsx
+++ b/src/utils/GlobalStyles.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Global, css, useTheme } from '@emotion/react';
-import { pseudoSelectors } from '../system';
+import { pseudoSelectors } from 'system';
 
 const GlobalStyles: React.FC = () => {
   const theme = useTheme();

--- a/src/utils/StyleguidistWrapper.tsx
+++ b/src/utils/StyleguidistWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Flex from '../components/Flex';
+import Flex from 'components/Flex';
 import ThemeProvider from './ThemeProvider';
 
 const StyleguidistWrapper: React.FC = ({ children }) => (

--- a/src/utils/ThemeProvider.tsx
+++ b/src/utils/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
-import { theme as defaultTheme, Theme } from '../theme';
+import { theme as defaultTheme, Theme } from 'theme';
 import GlobalStyles from './GlobalStyles';
 
 interface ThemeProviderProps {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Theme } from '../theme';
+import { Theme } from 'theme';
 import React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';

--- a/src/utils/useTheme.tsx
+++ b/src/utils/useTheme.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ThemeContext } from '@emotion/react';
-import { Theme } from '../theme';
+import { Theme } from 'theme';
 
 /**
  * A React hook that allows to retrieve the theme within a functional component

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,6 +1,15 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const shouldForwardProp = require('@styled-system/should-forward-prop');
+const fromPairs = require('lodash/fromPairs');
+const tsconfig = require('./tsconfig.json');
+
+const aliasMapperFromTSPaths = fromPairs(
+  Object.entries(tsconfig.compilerOptions.paths).map(([alias, [aliasedPath]]) => [
+    alias.replace(/\/\*/, ''),
+    path.resolve(__dirname, aliasedPath.replace(/\*/, '')),
+  ])
+);
 
 module.exports = {
   require: [path.join(__dirname, 'styleguide.setup.js')],
@@ -50,12 +59,7 @@ module.exports = {
     },
     resolve: {
       extensions: ['.tsx', '.ts'],
-      alias: {
-        system: path.resolve(__dirname, 'src/system'),
-        theme: path.resolve(__dirname, 'src/theme'),
-        components: path.resolve(__dirname, 'src/components/'),
-        utils: path.resolve(__dirname, 'src/utils/'),
-      },
+      alias: aliasMapperFromTSPaths,
     },
   },
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -48,5 +48,14 @@ module.exports = {
         },
       ],
     },
+    resolve: {
+      extensions: ['.tsx', '.ts'],
+      alias: {
+        system: path.resolve(__dirname, 'src/system'),
+        theme: path.resolve(__dirname, 'src/theme'),
+        components: path.resolve(__dirname, 'src/components/'),
+        utils: path.resolve(__dirname, 'src/utils/'),
+      },
+    },
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "test-utils": ["jest/utils"]
+      "test-utils": ["jest/utils"],
+      "system": ["src/system"],
+      "theme": ["src/theme"],
+      "components/*": ["src/components/*"],
+      "utils/*": ["src/utils/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
### Background

This PR lays the groundwork for a small docs refactor. Moving files around is hard when you have relative paths, since you have to update a million items when moving stuff between folders.

Unfortunately, absolute paths were not an option a while ago, since the `*.d.ts` declaration files had broken paths (i.e. absolute didn't get replaced with relative). Typescript itself doesn't support it and [**won't** support it](https://github.com/Microsoft/TypeScript/issues/15479) so our options were limited or required adding a bundler like rollup or webpack just for a path transformation (something which to me seemed too convoluted).

Luckily, there's [a new package](https://github.com/justkey007/tsc-alias) that helps make this declaration file re-rewite easy! In this PR we use that and move to absolute paths so that we can easily move components around with minimal changes

### Changes

- Add re-write command in build steps
- Re-write all relative imports to absolute
- Add path aliases to `tsconfig.json`
- Add module resolutions for docs building in webpack (unrelated to the library, only related to docs)

### Testing

- `npm run validate` passes
- `npm run build` passes
- Docs are shown correctly
- Installed this branch on an existing project (panther) and validated that TS is ok there as well
