### PR TITLE
Downgrade `@types/react-dom` in order to play along with Panther

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/lodash": "^4.14.170",
     "@types/reach__menu-button": "^0.1.1",
     "@types/react": "^17.0.11",
-    "@types/react-dom": "^17.0.7",
+    "@types/react-dom": "^17.0.6",
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/styled-system": "^5.1.11",
     "@types/styled-system__css": "^5.0.15",


### PR DESCRIPTION
### Background

Types are conflicting with Panther, as we have tons of TS errors from conflicting type resolutions.
![image (1)](https://user-images.githubusercontent.com/1022166/125059503-0fdfea80-e0b4-11eb-8cef-737b167281e9.png)


### Changes

- Downgrade types for `react-dom`

### Testing

- npm run test
- Link and play along with Panther
