### PR TITLE
Add types as strict dependency for `react-dom`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3555,9 +3555,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.7.tgz",
-      "integrity": "sha512-Wd5xvZRlccOrCTej8jZkoFZuZRKHzanDDv1xglI33oBNFMWrqOSzrvWFw7ngSiZjrpJAzPKFtX7JvuXpkNmQHA==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.6.tgz",
+      "integrity": "sha512-MGTI+TudxAnGTj8aco8mogaPSJGK2Whje7OZh1CxNLRyhJpTZg/pGQpIbCT0eCVFQyH7UFpdvCqQEThHIp/gsA==",
       "requires": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/lodash": "^4.14.170",
     "@types/reach__menu-button": "^0.1.1",
     "@types/react": "^17.0.11",
-    "@types/react-dom": "^17.0.6",
+    "@types/react-dom": "17.0.6",
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/styled-system": "^5.1.11",
     "@types/styled-system__css": "^5.0.15",


### PR DESCRIPTION
### Background

Types for `react-dom` should be strict as the `package-lock` does not get updated and creates conflicts for Panther and `reach` components.

### Changes

- Make `@types/react-dom` stick to `17.0.6`
- Update `package-lock`
