### PR TITLE
Downgrade `@types/react` in order to play along with Panther

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3532,9 +3532,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/reach__menu-button": {
       "version": "0.1.1",
@@ -3545,9 +3545,9 @@
       }
     },
     "@types/react": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
-      "integrity": "sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.6.tgz",
+      "integrity": "sha512-u/TtPoF/hrvb63LdukET6ncaplYsvCvmkceasx8oG84/ZCsoLxz9Z/raPBP4lTAiWW1Jb889Y9svHmv8R26dWw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3571,9 +3571,9 @@
       }
     },
     "@types/scheduler": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/history": "^4.7.8",
     "@types/lodash": "^4.14.170",
     "@types/reach__menu-button": "^0.1.1",
-    "@types/react": "^17.0.11",
+    "@types/react": "17.0.6",
     "@types/react-dom": "17.0.6",
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/styled-system": "^5.1.11",


### PR DESCRIPTION
### Background

`git bisect` with the pounce dependency within Panther indicates that we should downgrade the types in order to avoid conflicts with the `@reach` packages.

### Changes

- Restrict `@types/react` versioning.
