### PR TITLE
Downgrade `@types/react` to align with previous version working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3545,9 +3545,9 @@
       }
     },
     "@types/react": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
-      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
+      "version": "16.14.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz",
+      "integrity": "sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/history": "^4.7.8",
     "@types/lodash": "^4.14.170",
     "@types/reach__menu-button": "^0.1.1",
-    "@types/react": "17.0.5",
+    "@types/react": "16.14.5",
     "@types/react-dom": "17.0.5",
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/styled-system": "^5.1.11",


### PR DESCRIPTION
### Background

Moving `@types/react` to https://github.com/panther-labs/pounce/blob/a91a50f3ec4164ff59524ac0f73a4474c3e55c48/package-lock.json#L3553-L3569 as working version v0.97.2
