### PR TITLE
Fix: align resolutions to v0.97.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3545,9 +3545,9 @@
       }
     },
     "@types/react": {
-      "version": "16.14.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz",
-      "integrity": "sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz",
+      "integrity": "sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/history": "^4.7.8",
     "@types/lodash": "^4.14.170",
     "@types/reach__menu-button": "^0.1.1",
-    "@types/react": "16.14.5",
+    "@types/react": "17.0.8",
     "@types/react-dom": "17.0.5",
     "@types/react-textarea-autosize": "^4.3.5",
     "@types/styled-system": "^5.1.11",


### PR DESCRIPTION
### Background
Dependencies should be aligned with `pounce v0.92` as types for `react` and `react-dom` are way off.
