### PR TITLE
feat(combobox): add `withClearSelectionControl` prop to `Combobox`

### DIFF
--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -27,8 +27,21 @@ const ControlledCombobox: React.FC<Partial<ComboboxProps<Item>>> = props => {
 
 describe('Combobox', () => {
   it('renders', () => {
-    const { container } = renderWithTheme(<ControlledCombobox />);
+    const { container, getByText, getByPlaceholderText } = renderWithTheme(<ControlledCombobox />);
     expect(container).toMatchSnapshot();
+
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturer'));
+    expect(container).toMatchSnapshot();
+
+    fireClickAndMouseEvents(getByText('Toyota'));
+    expect(container).toMatchSnapshot();
+  });
+
+  it('doesn\'t render a "clear selection" button when no option is selected', () => {
+    const { queryByText, getByPlaceholderText } = renderWithTheme(<ControlledCombobox />);
+
+    fireClickAndMouseEvents(getByPlaceholderText('Select manufacturer'));
+    expect(queryByText('Clear Selection')).not.toBeInTheDocument();
   });
 
   it('clears selected value when the "clear selection" button is clicked', () => {

--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -1,0 +1,52 @@
+import { renderWithTheme, fireClickAndMouseEvents } from 'test-utils';
+import React from 'react';
+import Combobox, { ComboboxProps } from './index';
+
+type Item = { value: string; category: string };
+
+const items: Item[] = [
+  { value: 'Toyota', category: 'Normal' },
+  { value: 'Ford', category: 'Normal' },
+  { value: 'Chevrolet', category: 'Luxury' },
+];
+
+const ControlledCombobox: React.FC<Partial<ComboboxProps<Item>>> = props => {
+  const [selectedManufacturer, updateSelectedManufacturer] = React.useState<Item | null>(null);
+  return (
+    <Combobox
+      label="Choose a car manufacturer"
+      onChange={updateSelectedManufacturer}
+      value={selectedManufacturer}
+      placeholder="Select manufacturer"
+      items={items}
+      itemToString={item => item.value}
+      {...props}
+    />
+  );
+};
+
+describe('Combobox', () => {
+  it('renders', () => {
+    const { container } = renderWithTheme(<ControlledCombobox />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('clears selected value when the "clear selection" button is clicked', () => {
+    const { getByText, getByPlaceholderText } = renderWithTheme(<ControlledCombobox />);
+
+    const selectionInput = getByPlaceholderText('Select manufacturer');
+    const selectionValue = 'Toyota';
+
+    expect(selectionInput).not.toHaveValue();
+    fireClickAndMouseEvents(selectionInput);
+    fireClickAndMouseEvents(getByText(selectionValue));
+    expect(selectionInput).toHaveValue(selectionValue);
+
+    const clearSelectionButton = getByText(
+      (_, { tagName, textContent }) => tagName === 'BUTTON' && textContent === 'Clear Selection'
+    );
+
+    fireClickAndMouseEvents(clearSelectionButton);
+    expect(selectionInput).not.toHaveValue();
+  });
+});

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -5,10 +5,12 @@ import { filter as fuzzySearch } from 'fuzzaldrin';
 import Box from '../Box';
 import Flex from '../Flex';
 import IconButton from '../IconButton';
+import AbstractButton from '../AbstractButton';
 import { InputControl, InputElement, InputLabel, InputElementProps } from '../utils/Input';
 import { typedMemo } from '../../utils/helpers';
 import Menu from '../utils/Menu';
 import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
+import Icon from '../Icon';
 
 export type ComboboxProps<T> = {
   /** Callback when the selection changes */
@@ -79,6 +81,9 @@ export type ComboboxProps<T> = {
 
   /** The maximum height (in pixels) of the MultiCombobox dropdown. Defaults to 300. */
   maxHeight?: number;
+
+  /** Whether a clear selection control should be available to the user */
+  withClearSelectionControl?: boolean;
 };
 
 /**
@@ -102,6 +107,7 @@ function Combobox<Item>({
   invalid,
   required,
   hidden,
+  withClearSelectionControl = true,
   ...rest
 }: ComboboxProps<Item>): React.ReactElement<ComboboxProps<Item>> {
   // convert item to a string with a fallback of empty string
@@ -144,6 +150,7 @@ function Combobox<Item>({
         toggleMenu,
         openMenu,
         closeMenu,
+        clearSelection,
       }) => {
         const comboboxVariant = getVariant(isOpen);
 
@@ -243,6 +250,28 @@ function Combobox<Item>({
               isOpen={isOpen && results.length > 0}
               {...getMenuProps()}
             >
+              {withClearSelectionControl && (
+                <Box
+                  as="li"
+                  listStyle="none"
+                  backgroundColor="navyblue-350"
+                  position="sticky"
+                  top={0}
+                >
+                  <AbstractButton
+                    width="100%"
+                    onClick={() => clearSelection()}
+                    fontSize="x-small"
+                    color="teal-200"
+                    _hover={{ textDecoration: 'underline' }}
+                  >
+                    <Flex align="center" spacing={1} py={2} px={4}>
+                      <Icon size="small" type="close-circle" />
+                      <Box as="span">Clear Selection</Box>
+                    </Flex>
+                  </AbstractButton>
+                </Box>
+              )}
               <ComboBoxItems
                 items={results}
                 disableItem={disableItem}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -83,7 +83,7 @@ export type ComboboxProps<T> = {
   maxHeight?: number;
 
   /** Whether a clear selection control should be available to the user */
-  withClearSelectionControl?: boolean;
+  showClearSelectionControl?: boolean;
 };
 
 /**
@@ -107,7 +107,7 @@ function Combobox<Item>({
   invalid,
   required,
   hidden,
-  withClearSelectionControl = true,
+  showClearSelectionControl = true,
   ...rest
 }: ComboboxProps<Item>): React.ReactElement<ComboboxProps<Item>> {
   // convert item to a string with a fallback of empty string
@@ -250,7 +250,7 @@ function Combobox<Item>({
               isOpen={isOpen && results.length > 0}
               {...getMenuProps()}
             >
-              {withClearSelectionControl && selectedItem && (
+              {showClearSelectionControl && selectedItem && (
                 <Box
                   as="li"
                   listStyle="none"

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -250,13 +250,14 @@ function Combobox<Item>({
               isOpen={isOpen && results.length > 0}
               {...getMenuProps()}
             >
-              {withClearSelectionControl && (
+              {withClearSelectionControl && selectedItem && (
                 <Box
                   as="li"
                   listStyle="none"
                   backgroundColor="navyblue-350"
                   position="sticky"
                   top={0}
+                  zIndex={1}
                 >
                   <AbstractButton
                     width="100%"
@@ -265,7 +266,7 @@ function Combobox<Item>({
                     color="teal-200"
                     _hover={{ textDecoration: 'underline' }}
                   >
-                    <Flex align="center" spacing={1} py={2} px={4}>
+                    <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
                       <Icon size="small" type="close-circle" />
                       <Box as="span">Clear Selection</Box>
                     </Flex>

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -1,0 +1,254 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Combobox renders 1`] = `
+.pounce-6 {
+  position: relative;
+}
+
+.pounce-2 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: transparent;
+  border-radius: 4px;
+  border-color: #3e516b;
+}
+
+.pounce-2:hover {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within span {
+  opacity: 1;
+  visibility: visible;
+}
+
+.pounce-2:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-0 {
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 32px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: relative;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  left: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(0, 14px) scale(1);
+  -moz-transform: translate(0, 14px) scale(1);
+  -ms-transform: translate(0, 14px) scale(1);
+  transform: translate(0, 14px) scale(1);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 400;
+}
+
+.pounce-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 8px;
+  pointer-events: none;
+}
+
+.pounce-4 {
+  outline: none;
+  line-height: 1;
+  border-radius: 4px;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-4:focus {
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-3 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: currentColor;
+}
+
+
+
+<div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-0-label"
+    class="pounce-6"
+    role="combobox"
+  >
+    <div
+      class="pounce-6"
+    >
+      <div
+        aria-disabled="false"
+        class="pounce-2"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-disabled="false"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="downshift-0-input"
+          placeholder="Select manufacturer"
+          readonly=""
+          type="text"
+          value=""
+        />
+        <label
+          class="pounce-1"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Choose a car manufacturer
+        </label>
+      </div>
+      <div
+        class="pounce-5"
+      >
+        <button
+          aria-label="Toggle Menu"
+          aria-pressed="false"
+          class="pounce-4"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            class="pounce-3"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10L12 15L17 10H7Z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-7"
+      id="downshift-0-menu"
+      role="listbox"
+    />
+  </div>
+</div>
+`;

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -252,3 +252,764 @@ exports[`Combobox renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`Combobox renders 2`] = `
+.pounce-6 {
+  position: relative;
+}
+
+.pounce-0 {
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 32px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: relative;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  left: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(0, 14px) scale(1);
+  -moz-transform: translate(0, 14px) scale(1);
+  -ms-transform: translate(0, 14px) scale(1);
+  transform: translate(0, 14px) scale(1);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 400;
+}
+
+.pounce-4 {
+  outline: none;
+  line-height: 1;
+  border-radius: 4px;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-4:focus {
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-3 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: currentColor;
+}
+
+
+
+.pounce-2 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: #23344e;
+  border-radius: 4px;
+  border-color: #23344e;
+}
+
+.pounce-2:hover {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within span {
+  opacity: 1;
+  visibility: visible;
+}
+
+.pounce-2:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 8px;
+  pointer-events: auto;
+}
+
+.pounce-11 {
+  margin-top: -3px;
+  border: 1px solid;
+  border-left-color: #0081c5;
+  border-right-color: #0081c5;
+  border-bottom-color: #0081c5;
+  border-top-color: #23344e;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  background-color: #3e516b;
+  z-index: 10;
+  position: absolute;
+  width: 100%;
+  max-height: 300px;
+  overflow: auto;
+}
+
+.pounce-8 {
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+  padding-left: 16px;
+  -webkit-transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  position: relative;
+  background-color: #3e516b;
+  word-break: break-all;
+}
+
+.pounce-8[aria-selected=true],
+[data-selected]>.pounce-8 {
+  background-color: #23344e;
+}
+
+<div>
+  <div
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-0-label"
+    aria-owns="downshift-0-menu"
+    class="pounce-6"
+    role="combobox"
+  >
+    <div
+      class="pounce-6"
+    >
+      <div
+        aria-disabled="false"
+        class="pounce-2"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-controls="downshift-0-menu"
+          aria-disabled="false"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="downshift-0-input"
+          placeholder="Select manufacturer"
+          readonly=""
+          type="text"
+          value=""
+        />
+        <label
+          class="pounce-1"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Choose a car manufacturer
+        </label>
+      </div>
+      <div
+        class="pounce-5"
+      >
+        <button
+          aria-label="Toggle Menu"
+          aria-pressed="false"
+          class="pounce-4"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            class="pounce-3"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 14L12 9L17 14H7Z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-7"
+      id="downshift-0-menu"
+      role="listbox"
+    />
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-11"
+      id="downshift-0-menu"
+      role="listbox"
+      style="transform: scale(1, 1); opacity: 1;"
+    >
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-8"
+        id="downshift-0-item-0"
+        role="option"
+      >
+        Toyota
+      </li>
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-8"
+        id="downshift-0-item-1"
+        role="option"
+      >
+        Ford
+      </li>
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-8"
+        id="downshift-0-item-2"
+        role="option"
+      >
+        Chevrolet
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`Combobox renders 3`] = `
+.pounce-6 {
+  position: relative;
+}
+
+.pounce-2 {
+  min-height: 47px;
+  position: relative;
+  border: 1px solid;
+  -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  background-color: transparent;
+  border-radius: 4px;
+  border-color: #3e516b;
+}
+
+.pounce-2:hover {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within {
+  border-color: #0081c5;
+}
+
+.pounce-2:focus-within span {
+  opacity: 1;
+  visibility: visible;
+}
+
+.pounce-2:focus-within label {
+  font-weight: 500;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+}
+
+.pounce-0 {
+  width: 100%;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 32px;
+  padding-top: 20px;
+  padding-bottom: 8px;
+  position: relative;
+  color: #f6f6f6;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pounce-0::-webkit-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::-moz-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0:-ms-input-placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-0::placeholder {
+  opacity: 0;
+  color: #f6f6f6;
+  -webkit-transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+
+
+.pounce-0:focus::-webkit-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::-moz-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus:-ms-input-placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:focus::placeholder {
+  opacity: 0.4;
+}
+
+.pounce-0:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 30px #192231 inset;
+  -webkit-text-fill-color: #f6f6f6;
+  border-radius: 4px;
+}
+
+.pounce-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 8px;
+  pointer-events: none;
+}
+
+.pounce-4 {
+  outline: none;
+  line-height: 1;
+  border-radius: 4px;
+  height: 32px;
+  width: 32px;
+  cursor: pointer;
+  color: #f6f6f6;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-4:focus {
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-3 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: currentColor;
+}
+
+
+
+.pounce-15 {
+  margin-top: -3px;
+  border: 1px solid;
+  border-left-color: #0081c5;
+  border-right-color: #0081c5;
+  border-bottom-color: #0081c5;
+  border-top-color: #23344e;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  background-color: #3e516b;
+  z-index: 10;
+  position: absolute;
+  width: 100%;
+  max-height: 300px;
+  overflow: auto;
+}
+
+.pounce-13 {
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+  padding-left: 16px;
+  -webkit-transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  position: relative;
+  background-color: #3e516b;
+  word-break: break-all;
+}
+
+.pounce-13[aria-selected=true],
+[data-selected]>.pounce-13 {
+  background-color: #23344e;
+}
+
+.pounce-1 {
+  pointer-events: none;
+  font-size: 0.875rem;
+  padding-left: 16px;
+  padding-right: 16px;
+  color: #bdbdbd;
+  top: 0;
+  left: 0;
+  position: absolute;
+  transform-origin: center left;
+  -webkit-transform: translate(6px, 4px) scale(0.65);
+  -moz-transform: translate(6px, 4px) scale(0.65);
+  -ms-transform: translate(6px, 4px) scale(0.65);
+  transform: translate(6px, 4px) scale(0.65);
+  -webkit-transition: -webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  font-weight: 500;
+}
+
+.pounce-11 {
+  background-color: #30415C;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.pounce-10 {
+  width: 100%;
+  font-size: 0.625rem;
+  color: #56e3c9;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+}
+
+.pounce-10:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.pounce-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.pounce-9>*:not(:last-child) {
+  margin-right: 6px;
+}
+
+.pounce-7 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: currentColor;
+}
+
+.pounce-12 {
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+  padding-left: 16px;
+  -webkit-transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: background-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  position: relative;
+  background-color: #1d2a3f;
+  word-break: break-all;
+}
+
+.pounce-12[aria-selected=true],
+[data-selected]>.pounce-12 {
+  background-color: #23344e;
+}
+
+<div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-0-label"
+    class="pounce-6"
+    role="combobox"
+  >
+    <div
+      class="pounce-6"
+    >
+      <div
+        aria-disabled="false"
+        class="pounce-2"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-disabled="false"
+          aria-invalid="false"
+          aria-labelledby="downshift-0-label"
+          aria-readonly="true"
+          autocomplete="off"
+          class="pounce-0"
+          id="downshift-0-input"
+          placeholder="Select manufacturer"
+          readonly=""
+          type="text"
+          value="Toyota"
+        />
+        <label
+          class="pounce-1"
+          for="downshift-0-input"
+          id="downshift-0-label"
+        >
+          Choose a car manufacturer
+        </label>
+      </div>
+      <div
+        class="pounce-5"
+      >
+        <button
+          aria-label="Toggle Menu"
+          aria-pressed="false"
+          class="pounce-4"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            class="pounce-3"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10L12 15L17 10H7Z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-15"
+      id="downshift-0-menu"
+      role="listbox"
+      style="transform: scale(0.9, 0.9); opacity: 0;"
+    >
+      <li
+        class="pounce-11"
+      >
+        <button
+          class="pounce-10"
+          type="button"
+        >
+          <span
+            class="pounce-9"
+          >
+            <svg
+              class="pounce-7"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm2.828 5.757L12 10.587l-2.828-2.83-1.415 1.415L10.587 12l-2.83 2.828 1.415 1.415L12 13.414l2.828 2.829 1.415-1.415L13.414 12l2.829-2.828-1.415-1.415z"
+              />
+            </svg>
+            <span
+              class="pounce-8"
+            >
+              Clear Selection
+            </span>
+          </span>
+        </button>
+      </li>
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-12"
+        id="downshift-0-item-0"
+        role="option"
+      >
+        Toyota
+      </li>
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-13"
+        id="downshift-0-item-1"
+        role="option"
+      >
+        Ford
+      </li>
+      <li
+        aria-disabled="false"
+        aria-selected="false"
+        class="pounce-13"
+        id="downshift-0-item-2"
+        role="option"
+      >
+        Chevrolet
+      </li>
+    </ul>
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-8"
+      id="downshift-0-menu"
+      role="listbox"
+    />
+    <ul
+      aria-labelledby="downshift-0-label"
+      class="pounce-8"
+      id="downshift-0-menu"
+      role="listbox"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Background

We always needed a way to be able to clear your selection in Comboboxes. Currently, this happens with an `ESC` keypress but that's not so obvious for users. With this PR we add an explicit way of clearing a `Combobox`'s value

### Designs

https://www.figma.com/file/xJGJA3FyFcamwsjFd9rLIT/Styles-and-Components-Library?node-id=210%3A241

### Screencast


https://user-images.githubusercontent.com/10436045/126487401-e1739e81-2f8d-458f-b454-a067d5c5a322.mov


### Changes

- Add "Clear Selection" button
- Add `withClearSelectionControl` to enable/disable this behaviour

### Testing

- `npm run test`

### Notes

When selecting a value, the animation that closes the menu has a "flash" of green content (due to the "clear selection" button appearing as the animation for menu closing starts). I consider this an expected side-effect and I can't think of a non-hacky way to combat this
