### PR TITLE
fix: change title type in ControlledAlertProps interface

### DIFF
--- a/src/components/utils/ControlledAlert/ControlledAlert.tsx
+++ b/src/components/utils/ControlledAlert/ControlledAlert.tsx
@@ -8,7 +8,7 @@ import useAlertStyles from './useAlertStyles';
 
 export interface ControlledAlertProps {
   /** The main text of the the alert */
-  title?: string;
+  title?: React.ReactNode;
 
   /** Whether the alert is visible */
   open: boolean;


### PR DESCRIPTION
### Background

Change ControlledAlertProps title property to `React.ReactNode` in order to avoid `@ts-ignore` when we passing title as a react node.

### Changes

- Change ControlledAlertProps title property to `React.ReactNode`

### Testing

- Manual
