### PR TITLE
fix: make key unique

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, ...rest }) => {
 
           return (
             <Flex
-              key={item.href}
+              key={`${item.href}_${item.text}_${index}`}
               as="li"
               alignItems="center"
               fontSize="medium"

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -27,7 +27,7 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, ...rest }) => {
 
           return (
             <Flex
-              key={`${item.href}_${item.text}_${index}`}
+              key={`${item.href}_${item.text}`}
               as="li"
               alignItems="center"
               fontSize="medium"


### PR DESCRIPTION
### Background

React key issue when we have the same url on more than one Breadcrumbs.

### Changes

- Add a bit more unique identifier.

### Testing

- Manual

### Screenshots
![image](https://user-images.githubusercontent.com/20260392/134934673-b7771103-597c-4528-bf6a-c7cf7acf2102.png)


