### PR TITLE
fix: add `sx` prop to `Button` typings

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,7 +6,9 @@ import Spinner from '../Spinner';
 import Icon, { IconProps } from '../Icon';
 import { Theme } from '../../theme';
 
-export interface ButtonProps extends NativeAttributes<'button'>, Pick<BoxProps, 'as' | 'to'> {
+export interface ButtonProps
+  extends NativeAttributes<'button'>,
+    Pick<BoxProps, 'as' | 'to' | 'sx'> {
   /** The size (height) of the button */
   size?: 'small' | 'medium' | 'large';
 


### PR DESCRIPTION
### Background

Had some `TS` errors when using `sx` on the `Button` component. This adds the TS types to fix the error.

### Testing

- Add `sx` to `Button.text.tsx` and observe error / observed it being fixed.
