### PR TITLE
Revamp transparent alerts

### DIFF
--- a/src/components/Alert/Alert.mdx
+++ b/src/components/Alert/Alert.mdx
@@ -3,13 +3,31 @@ Alerts can be transparent:
 ```typescript jsx
 <Box width={1}>
   <Box mb={3}>
-    <Alert variant="success" mb={3} title="This is a success alert" />
+    <Alert variant="success" title="This is a success alert" />
   </Box>
   <Box mb={3}>
-    <Alert variant="info" mb={3} title="This is an info alert" />
+    <Alert
+      variant="info"
+      actions={
+        <Flex spacing={2}>
+          <Button
+            size="medium"
+            variant="outline"
+            variantColor="gray-300"
+            onClick={() => alert('Boom!')}
+          >
+            I Alert
+          </Button>
+          <Button size="medium" onClick={() => alert('Boom!')}>
+            I Alert
+          </Button>
+        </Flex>
+      }
+      title="This is an info alert"
+    />
   </Box>
   <Box mb={3}>
-    <Alert variant="warning" mb={3} title="This is a warning alert" />
+    <Alert variant="warning" title="This is a warning alert" />
   </Box>
   <Box mb={3}>
     <Alert variant="error" title="This is an error alert" />
@@ -99,22 +117,10 @@ Alerts can be hidden by the user:
 ```typescript jsx
 <Box width={1}>
   <Box mb={3}>
-    <Alert
-      variant="success"
-      variantBackgroundStyle="solid"
-      title="This is a success alert"
-      description="This is a nice description of the title"
-      discardable
-    />
+    <Alert variant="success" title="This is a success alert" discardable />
   </Box>
   <Box mb={3}>
-    <Alert
-      variant="info"
-      variantBackgroundStyle="solid"
-      title="This is an info alert"
-      description="This is a nice description of the title"
-      discardable
-    />
+    <Alert variant="info" title="This is an info alert" discardable />
   </Box>
   <Box mb={3}>
     <Alert
@@ -149,24 +155,58 @@ Alerts can be hidden by the user:
 Alerts can have actions associated with them:
 
 ```typescript jsx
-<Box>
+<Box width={1}>
+  <Box mb={3}>
+    <Alert
+      variant="info"
+      actions={
+        <Flex spacing={2}>
+          <Button
+            size="medium"
+            variant="outline"
+            variantColor="gray-300"
+            onClick={() => alert('Boom!')}
+          >
+            I Alert
+          </Button>
+          <Button size="medium" onClick={() => alert('Boom!')}>
+            I Alert
+          </Button>
+        </Flex>
+      }
+      title="This is an info alert"
+    />
+  </Box>
   <Box mb={3}>
     <Alert
       variant="warning"
-      variantBackgroundStyle="solid"
       title="This is a warning alert"
-      description="This is a nice description of the title"
-      actions={<Button onClick={() => alert('Boom!')}>I Alert</Button>}
+      actions={
+        <Button size="medium" onClick={() => alert('Boom!')}>
+          I Alert
+        </Button>
+      }
     />
   </Box>
-  <Box>
-    <Alert
-      variant="error"
-      variantBackgroundStyle="solid"
-      title="This is an error alert"
-      description="This is a nice description of the title"
-      actions={({ close }) => <Button onClick={close}>I Close</Button>}
-    />
-  </Box>
+  <Flex spacing={4}>
+    <Box width="50%" mb={3}>
+      <Alert
+        variant="warning"
+        variantBackgroundStyle="solid"
+        title="This is a warning alert"
+        description="This is a nice description of the title"
+        actions={<Button onClick={() => alert('Boom!')}>I Alert</Button>}
+      />
+    </Box>
+    <Box width="50%">
+      <Alert
+        variant="error"
+        variantBackgroundStyle="solid"
+        title="This is an error alert"
+        description="This is a nice description of the title"
+        actions={({ close }) => <Button onClick={close}>I Close</Button>}
+      />
+    </Box>
+  </Flex>
 </Box>
 ```

--- a/src/components/utils/ControlledAlert/ControlledAlert.tsx
+++ b/src/components/utils/ControlledAlert/ControlledAlert.tsx
@@ -48,7 +48,10 @@ const ControlledAlert = React.forwardRef<HTMLDivElement, ControlledAlertProps>(
     },
     ref
   ) {
-    const { icon, titleColor, ...styles } = useAlertStyles({ variant, variantBackgroundStyle });
+    const { icon, iconColor, titleColor, ...styles } = useAlertStyles({
+      variant,
+      variantBackgroundStyle,
+    });
     const id = useId();
 
     if (!open) {
@@ -56,52 +59,54 @@ const ControlledAlert = React.forwardRef<HTMLDivElement, ControlledAlertProps>(
     }
 
     return (
-      <Box
+      <Flex
         ref={ref}
-        p={4}
         role="dialog"
         aria-labelledby={`${id}-title`}
         aria-describedby={`${id}-description`}
         {...styles}
         {...rest}
       >
-        {title && (
-          <Flex as="header" align="center" fontSize="large">
-            {icon && <Icon type={icon} mr={2} size="large" />}
-            <Box
-              as="h4"
-              color={titleColor}
-              fontWeight={description ? 'bold' : 'normal'}
-              fontSize={description ? 'x-large' : 'large'}
-              flexGrow={1}
-              mr="auto"
-              id={`${id}-title`}
-            >
-              {title}
-            </Box>
-            {discardable && (
-              <Box my={-3} mr={-3} ml={3}>
-                <IconButton
-                  aria-label="Discard"
-                  variant="unstyled"
-                  icon="close"
-                  onClick={onClose}
-                />
+        <Flex
+          flexGrow={1}
+          direction={variantBackgroundStyle === 'solid' ? 'column' : 'row'}
+          align={variantBackgroundStyle === 'solid' ? 'flex-start' : 'center'}
+        >
+          <Box>
+            {title && (
+              <Flex as="header" align="center" fontSize="large">
+                {icon && <Icon type={icon} mr={2} color={iconColor} size="large" />}
+                <Box
+                  as="h4"
+                  color={titleColor}
+                  fontWeight={description ? 'bold' : 'normal'}
+                  fontSize={description ? 'x-large' : 'large'}
+                  flexGrow={1}
+                  mr="auto"
+                  id={`${id}-title`}
+                >
+                  {title}
+                </Box>
+              </Flex>
+            )}
+            {description && (
+              <Box as="p" mt={title ? 3 : 0} fontSize="medium">
+                {description}
               </Box>
             )}
-          </Flex>
-        )}
-        {description && (
-          <Box as="p" mt={title ? 3 : 0} fontSize="medium">
-            {description}
+          </Box>
+          {actions && (
+            <Flex mt={variantBackgroundStyle === 'solid' ? 6 : 0} mr={0} ml="auto">
+              {typeof actions === 'function' ? actions({ close }) : actions}
+            </Flex>
+          )}
+        </Flex>
+        {discardable && (
+          <Box my={-2} mr={-2} ml={2}>
+            <IconButton aria-label="Discard" variant="unstyled" icon="close" onClick={onClose} />
           </Box>
         )}
-        {actions && (
-          <Flex mt={6} justify="flex-end" as="footer">
-            {typeof actions === 'function' ? actions({ close }) : actions}
-          </Flex>
-        )}
-      </Box>
+      </Flex>
     );
   }
 );

--- a/src/components/utils/ControlledAlert/useAlertStyles.tsx
+++ b/src/components/utils/ControlledAlert/useAlertStyles.tsx
@@ -43,7 +43,10 @@ const useAlertStyles = ({ variant, variantBackgroundStyle }: UseControlledAlertS
   switch (variantBackgroundStyle) {
     case 'transparent':
       return {
+        p: 2,
+        align: 'center',
         icon: getAlertVariantIcon(variant),
+        iconColor: color,
         border: '1px solid',
         borderColor: color,
         borderRadius: 'large' as const,
@@ -52,6 +55,7 @@ const useAlertStyles = ({ variant, variantBackgroundStyle }: UseControlledAlertS
     case 'solid':
     default:
       return {
+        p: 4,
         backgroundColor: 'navyblue-400' as const,
         borderLeft: variant === 'default' ? 'none' : ('4px solid' as const),
         borderRadius: 'small' as const,


### PR DESCRIPTION
### Background

Revamp the transparent Alerts so that the action buttons are not placed below the title and description.

### Changes

- Move Action buttons in transparent Alerts
- Discardable prop does not depend on the title anymore.
### Designs
https://www.figma.com/file/xJGJA3FyFcamwsjFd9rLIT/Styles-and-Components-Library?node-id=243%3A42
### Screenshots

![Screenshot 2021-10-18 at 2 18 36 PM](https://user-images.githubusercontent.com/15084305/137751040-085a11a8-90b4-4380-80aa-dbd06c87269d.png)
![Screenshot 2021-10-18 at 1 59 08 PM](https://user-images.githubusercontent.com/15084305/137751049-2a239176-741a-4d18-b21d-69a7c01c181c.png)

### Testing

- manually
