### PR TITLE
feat: change text from string to ReactNode

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -3,12 +3,16 @@ By default the Breadcrumbs will render anchor tags (`a`):
 ```typescript jsx
 const items = [
   {
-    text: 'First page',
+    title: 'First page',
     href: '/#/Box',
   },
   {
-    text: 'Second page',
+    title: 'Second page',
     href: '/#/Flex',
+  },
+  {
+    title: <MyCustomTitle />,
+    href: '/#/MyCustomTitle',
   },
 ];
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -14,30 +14,3 @@ const items = [
 
 <Breadcrumbs items={items} />;
 ```
-
-You can easily override that by providing your own custom renderer:
-
-```typescript jsx
-const items = [
-  {
-    text: 'I am not',
-    href: '/#/Table',
-  },
-  {
-    text: 'a Link',
-    href: '/#/Box',
-  },
-  {
-    text: 'I am simply',
-    href: '/#/Flex',
-  },
-  {
-    text: 'a pretty div',
-    href: '/#/Dropdown',
-  },
-];
-
-const itemRenderer = item => <div>{item.text}</div>;
-
-<Breadcrumbs items={items} itemRenderer={itemRenderer} />;
-```

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -3,15 +3,15 @@ By default the Breadcrumbs will render anchor tags (`a`):
 ```typescript jsx
 const items = [
   {
-    title: 'First page',
+    children: 'First page',
     href: '/#/Box',
   },
   {
-    title: 'Second page',
+    children: 'Second page',
     href: '/#/Flex',
   },
   {
-    title: <MyCustomTitle />,
+    children: <MyCustomTitle />,
     href: '/#/MyCustomTitle',
   },
 ];

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,19 +7,14 @@ import Link, { LinkProps } from '../Link';
 export interface BreadcrumbItem {
   /** The URL that this Breadcrumbs should navigate to when clicked */
   href: string;
-  /** Title is the text that should be displayed on this particular Breadcrumb
-   * element can be: numbers, strings, elements or an array (or fragment) containing these types.
+  /** The react node that will be displayed on this particular Breadcrumb
+   * children can be: numbers, strings, elements or an array (or fragment) containing these types.
    */
-  title: React.ReactNode;
-  /**
-   * @deprecated use node property instead.
-   * The text that should be displayed on this particular Breadcrumb
-   */
-  text?: string;
+  children: React.ReactNode;
 }
 
 export interface BreadcrumbProps extends Pick<LinkProps, 'as'> {
-  /** A list of `BreadcrumbsItem` objects ( `{href,title,text}` ) that will construct the Breadcrumb */
+  /** A list of `BreadcrumbsItem` objects ( `{href,children}` ) that will construct the Breadcrumb */
   items: BreadcrumbItem[];
 }
 
@@ -49,8 +44,7 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, ...rest }) => {
                 data-active={isLastBreadcrumb ? true : undefined}
                 {...rest}
               >
-                {/* TODO: remove item.text  */}
-                {item.title || item.text}
+                {item.children}
               </Link>
               {!isLastBreadcrumb && (
                 <Icon

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,9 +7,10 @@ import Link, { LinkProps } from '../Link';
 export interface BreadcrumbItem {
   /** The URL that this Breadcrumbs should navigate to when clicked */
   href: string;
-
-  /** The text that should be displayed on this particular Breadcrumb */
-  text: string;
+  /** The text that should be displayed on this particular Breadcrumb
+   * text can be: numbers, strings, elements or an array (or fragment) containing these types.
+   */
+  text: React.ReactNode;
 }
 
 export interface BreadcrumbProps extends Pick<LinkProps, 'as'> {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,14 +7,19 @@ import Link, { LinkProps } from '../Link';
 export interface BreadcrumbItem {
   /** The URL that this Breadcrumbs should navigate to when clicked */
   href: string;
-  /** The text that should be displayed on this particular Breadcrumb
-   * text can be: numbers, strings, elements or an array (or fragment) containing these types.
+  /** Title is the text that should be displayed on this particular Breadcrumb
+   * element can be: numbers, strings, elements or an array (or fragment) containing these types.
    */
-  text: React.ReactNode;
+  title: React.ReactNode;
+  /**
+   * @deprecated use node property instead.
+   * The text that should be displayed on this particular Breadcrumb
+   */
+  text?: string;
 }
 
 export interface BreadcrumbProps extends Pick<LinkProps, 'as'> {
-  /** A list of `BreadcrumbsItem` objects ( `{href,text}` ) that will construct the Breadcrumb */
+  /** A list of `BreadcrumbsItem` objects ( `{href,title,text}` ) that will construct the Breadcrumb */
   items: BreadcrumbItem[];
 }
 
@@ -44,7 +49,8 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, ...rest }) => {
                 data-active={isLastBreadcrumb ? true : undefined}
                 {...rest}
               >
-                {item.text}
+                {/* TODO: remove item.text  */}
+                {item.title || item.text}
               </Link>
               {!isLastBreadcrumb && (
                 <Icon


### PR DESCRIPTION
### Background

Ability to pass a react node instead of only string in breadcrumb item title!

### Changes

- [x] Modify text  shape
- [x] Remove unused part from mdx

### Testing

- Manual

### Screenshot

![Screenshot 2021-11-15 at 4 44 38 PM](https://user-images.githubusercontent.com/20260392/141801301-4e69401d-6308-4b8c-a9e0-e754d6f8d8e3.png)
