### PR TITLE
feat: change alert title to be more consistent with figma designs

### DIFF
--- a/src/components/utils/ControlledAlert/ControlledAlert.tsx
+++ b/src/components/utils/ControlledAlert/ControlledAlert.tsx
@@ -74,13 +74,13 @@ const ControlledAlert = React.forwardRef<HTMLDivElement, ControlledAlertProps>(
         >
           <Box>
             {title && (
-              <Flex as="header" align="center" fontSize="large">
+              <Flex as="header" align="center">
                 {icon && <Icon type={icon} mr={2} color={iconColor} size="large" />}
                 <Box
-                  as="h4"
+                  as="h2"
                   color={titleColor}
                   fontWeight={description ? 'bold' : 'normal'}
-                  fontSize={description ? 'x-large' : 'large'}
+                  fontSize={description ? 'large' : 'medium'}
                   flexGrow={1}
                   mr="auto"
                   id={`${id}-title`}


### PR DESCRIPTION
### Background

Reduce the font size by one level on Alert title 

Figma Designs : 

- https://www.figma.com/file/jaP87DKwYCoO3o1bAYp6OH/02-System-Health-%E2%9C%85?node-id=81%3A7579
- https://www.figma.com/file/LkZk4NngNuOGFH3VNzS36z/08-Integrations-%E2%9C%85?node-id=851%3A38751

### Changes

- Alert component

### Testing

- Manual

### Screenshots
#### Before
![Screenshot 2021-12-02 at 12 29 49 PM](https://user-images.githubusercontent.com/20260392/144405088-0aa5ce00-5add-42b8-ac85-02f69ccc96f6.png)

#### After 
![Screenshot 2021-12-02 at 12 33 31 PM](https://user-images.githubusercontent.com/20260392/144405433-e2055e06-27bc-400a-bc2b-44d0217770e0.png)


