### PR TITLE
Add radio size

### DIFF
--- a/src/components/Radio/Radio.mdx
+++ b/src/components/Radio/Radio.mdx
@@ -19,8 +19,9 @@ const Example = () => {
           checked={checked === 'B'}
           onChange={() => setChecked('B')}
           value="B"
+          size="large"
           name="example"
-          label="Invalid"
+          label="A Large Radio"
         />
       </Box>
       <Box>

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -6,6 +6,9 @@ export type RadioProps = NativeAttributes<'input'> & {
   /** The label associated with the Radio. Appears on the right. */
   label?: string;
 
+  /** The size of the Radio. Defaults to `small`. */
+  size?: 'medium' | 'large';
+
   /** Whether the checkbox is currently disabled */
   disabled?: boolean;
 
@@ -18,7 +21,7 @@ export type RadioProps = NativeAttributes<'input'> & {
  *  can pass it as many native attrs as you wish.
  */
 const Radio = React.forwardRef<HTMLInputElement, RadioProps>(function Radio(
-  { checked, label, disabled, invalid, hidden, readOnly, ...rest },
+  { checked, label, disabled, invalid, hidden, size = 'medium', readOnly, ...rest },
   ref
 ) {
   const radioStyles = useRadioStyles({ invalid, checked });
@@ -29,8 +32,8 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>(function Radio(
       display="inline-flex"
       alignItems="center"
       cursor="pointer"
-      fontSize="medium"
-      fontWeight="medium"
+      fontSize={size === 'medium' ? 'medium' : 'x-large'}
+      fontWeight={size === 'medium' ? 'medium' : 'bold'}
       verticalAlign="top"
       aria-disabled={disabled}
       aria-hidden={hidden}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -6,7 +6,7 @@ export type RadioProps = NativeAttributes<'input'> & {
   /** The label associated with the Radio. Appears on the right. */
   label?: string;
 
-  /** The size of the Radio. Defaults to `small`. */
+  /** The size of the Radio. Defaults to `medium`. */
   size?: 'medium' | 'large';
 
   /** Whether the checkbox is currently disabled */


### PR DESCRIPTION
### Background

Add a new prop to Radio to support [designs](https://www.figma.com/file/LkZk4NngNuOGFH3VNzS36z/08-Integrations-%E2%9C%85?node-id=2473%3A61801) 

### Changes

- Add size prop to Radio
### Screenshots
![image](https://user-images.githubusercontent.com/15084305/155368399-cfd75db6-d0ad-45e9-ab68-38386b253670.png)

### Testing

- manually
