### PR TITLE
feat: expand multicombobox props

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const App = () => (
 )
 ```
 
-Make sure to wrap your **entire** app with a `<ThemeProvider>` to avoid un-necessary reconsiliations
+Make sure to wrap your **entire** app with a `<ThemeProvider>` to avoid un-necessary reconciliations
 and to gain in performance.
 
 The next step would be to make sure you have your selected font-family installed. By default,

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -180,7 +180,7 @@ const Example5 = () => {
 <Example5 />;
 ```
 
-A MultiCombobox can have a custom placeholder passed to it
+A MultiCombobox can have custom content passed to it
 
 ```typescript jsx
 const Example6 = () => {
@@ -196,7 +196,7 @@ const Example6 = () => {
         <MultiCombobox
           label="Filter columns"
           variant="solid"
-          renderPlaceHolder={() => <div>Filtered Columns ({selectedMoto.length})</div>}
+          renderContent={() => <div>Filtered Columns ({selectedMoto.length})</div>}
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
           hideLabel
           onChange={updateSelectedMoto}

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -216,17 +216,22 @@ A MultiCombobox can render a custom clear all selected element
 
 ```typescript jsx
 const Example7 = () => {
-  const [shaunTest, updateShaunTest] = React.useState(['Benelli', 'Ducati', 'BMW', 'Moto Guzzi']);
+  const [selectedMoto, updateSelectedMoto] = React.useState([
+    'Benelli',
+    'Ducati',
+    'BMW',
+    'Moto Guzzi',
+  ]);
   return (
     <>
       <Box width={0.4}>
         <MultiCombobox
           label="Filter columns"
           variant="solid"
-          placeholder={`Filtered Columns (${shaunTest.length})`}
+          placeholder={`Filtered Columns (${selectedMoto.length})`}
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
-          onChange={updateShaunTest}
-          value={shaunTest}
+          onChange={updateSelectedMoto}
+          value={selectedMoto}
           canClearAllAfter={4}
           alwaysUsePlaceholder
           renderClearAll={({ clearSelectedItems }) => {

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -185,7 +185,7 @@ A MultiCombobox can always show the placeholder.
 NOTE: you likely want to also pass the `hideLabel` prop as well so you don't have both a label and a placeholder showing at the same time
 
 ```typescript jsx
-const AlwaysShowPlaceholder = () => {
+const Example6 = () => {
   const [selectedMoto, updateSelectedMoto] = React.useState([
     'Benelli',
     'Ducati',
@@ -210,13 +210,13 @@ const AlwaysShowPlaceholder = () => {
   );
 };
 
-<AlwaysShowPlaceholder />;
+<Example6 />;
 ```
 
 A MultiCombobox can render a custom clear all selected element
 
 ```typescript jsx
-const RenderClearAll = () => {
+const Example7 = () => {
   const [shaunTest, updateShaunTest] = React.useState(['Benelli', 'Ducati', 'BMW', 'Moto Guzzi']);
   return (
     <>
@@ -255,13 +255,13 @@ const RenderClearAll = () => {
   );
 };
 
-<RenderClearAll />;
+<Example7 />;
 ```
 
 A MultiCombobox can have "solid" variant:
 
 ```typescript jsx
-const Example5 = () => {
+const Example8 = () => {
   const [selectedItems, updateSelectedItems] = React.useState([]);
   return (
     <Box width={0.3}>
@@ -278,13 +278,13 @@ const Example5 = () => {
   );
 };
 
-<Example5 />;
+<Example8 />;
 ```
 
 A MultiCombobox can have grouped items:
 
 ```typescript jsx
-const Example6 = () => {
+const Example9 = () => {
   const [selectedCar, updateSelectedCar] = React.useState([]);
   const [selectedMoto, updateSelectedMoto] = React.useState([]);
   return (
@@ -348,5 +348,5 @@ const Example6 = () => {
   );
 };
 
-<Example6 />;
+<Example9 />;
 ```

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -198,6 +198,7 @@ const Example6 = () => {
           variant="solid"
           renderPlaceHolder={() => <div>Filtered Columns ({selectedMoto.length})</div>}
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
+          hideLabel
           onChange={updateSelectedMoto}
           value={selectedMoto}
           canClearAllAfter={4}
@@ -211,59 +212,10 @@ const Example6 = () => {
 <Example6 />;
 ```
 
-A MultiCombobox can render a custom clear all selected element
-
-```typescript jsx
-const Example7 = () => {
-  const [selectedMoto, updateSelectedMoto] = React.useState([
-    'Benelli',
-    'Ducati',
-    'BMW',
-    'Moto Guzzi',
-  ]);
-  return (
-    <>
-      <Box width={0.4}>
-        <MultiCombobox
-          label="Filter columns"
-          variant="solid"
-          placeholder={`Filtered Columns (${selectedMoto.length})`}
-          items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
-          onChange={updateSelectedMoto}
-          value={selectedMoto}
-          canClearAllAfter={4}
-          alwaysUsePlaceholder
-          renderClearAll={({ clearSelectedItems }) => {
-            return (
-              <AbstractButton
-                width="100%"
-                onClick={() => {
-                  clearSelectedItems();
-                }}
-                fontSize="x-small"
-                color="teal-200"
-                _hover={{ textDecoration: 'underline' }}
-              >
-                <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
-                  <Icon size="small" type="close-circle" />
-                  <Box as="span">Clear Selection</Box>
-                </Flex>
-              </AbstractButton>
-            );
-          }}
-        />
-      </Box>
-    </>
-  );
-};
-
-<Example7 />;
-```
-
 A MultiCombobox can have "solid" variant:
 
 ```typescript jsx
-const Example8 = () => {
+const Example7 = () => {
   const [selectedItems, updateSelectedItems] = React.useState([]);
   return (
     <Box width={0.3}>
@@ -280,13 +232,13 @@ const Example8 = () => {
   );
 };
 
-<Example8 />;
+<Example7 />;
 ```
 
 A MultiCombobox can have grouped items:
 
 ```typescript jsx
-const Example9 = () => {
+const Example8 = () => {
   const [selectedCar, updateSelectedCar] = React.useState([]);
   const [selectedMoto, updateSelectedMoto] = React.useState([]);
   return (
@@ -350,5 +302,5 @@ const Example9 = () => {
   );
 };
 
-<Example9 />;
+<Example8 />;
 ```

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -147,6 +147,7 @@ const Example5 = () => {
     'BMW',
     'Moto Guzzi',
   ]);
+
   return (
     <>
       <Box width={0.4} mr={4}>
@@ -164,6 +165,7 @@ const Example5 = () => {
         <MultiCombobox
           label="Choose a car manufacturer"
           hideLabel
+          searchable
           variant="solid"
           placeholder="Choose a motorcycle manufacturer"
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
@@ -177,6 +179,83 @@ const Example5 = () => {
 };
 
 <Example5 />;
+```
+
+A MultiCombobox can always show the placeholder.
+NOTE: you likely want to also pass the `hideLabel` prop as well so you don't have both a label and a placeholder showing at the same time
+
+```typescript jsx
+const AlwaysShowPlaceholder = () => {
+  const [selectedMoto, updateSelectedMoto] = React.useState([
+    'Benelli',
+    'Ducati',
+    'BMW',
+    'Moto Guzzi',
+  ]);
+  return (
+    <>
+      <Box width={0.4}>
+        <MultiCombobox
+          label="Filter columns"
+          variant="solid"
+          placeholder={`Filtered Columns (${selectedMoto.length})`}
+          items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
+          onChange={updateSelectedMoto}
+          value={selectedMoto}
+          canClearAllAfter={4}
+          alwaysUsePlaceholder
+        />
+      </Box>
+    </>
+  );
+};
+
+<AlwaysShowPlaceholder />;
+```
+
+A MultiCombobox can render a custom clear all selected element
+
+```typescript jsx
+const RenderClearAll = () => {
+  const [shaunTest, updateShaunTest] = React.useState(['Benelli', 'Ducati', 'BMW', 'Moto Guzzi']);
+  return (
+    <>
+      <Box width={0.4}>
+        <MultiCombobox
+          label="Filter columns"
+          variant="solid"
+          placeholder={`Filtered Columns (${shaunTest.length})`}
+          items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
+          onChange={updateShaunTest}
+          value={shaunTest}
+          canClearAllAfter={4}
+          alwaysUsePlaceholder
+          renderClearAll={({ clearSelectedItems }) => {
+            return (
+              <AbstractButton
+                width="100%"
+                onClick={() => {
+                  console.log('hi');
+                  clearSelectedItems();
+                }}
+                fontSize="x-small"
+                color="teal-200"
+                _hover={{ textDecoration: 'underline' }}
+              >
+                <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
+                  <Icon size="small" type="close-circle" />
+                  <Box as="span">Clear Selection</Box>
+                </Flex>
+              </AbstractButton>
+            );
+          }}
+        />
+      </Box>
+    </>
+  );
+};
+
+<RenderClearAll />;
 ```
 
 A MultiCombobox can have "solid" variant:

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -165,7 +165,6 @@ const Example5 = () => {
         <MultiCombobox
           label="Choose a car manufacturer"
           hideLabel
-          searchable
           variant="solid"
           placeholder="Choose a motorcycle manufacturer"
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -180,8 +180,7 @@ const Example5 = () => {
 <Example5 />;
 ```
 
-A MultiCombobox can always show the placeholder.
-NOTE: you likely want to also pass the `hideLabel` prop as well so you don't have both a label and a placeholder showing at the same time
+A MultiCombobox can have a custom placeholder passed to it
 
 ```typescript jsx
 const Example6 = () => {
@@ -197,7 +196,7 @@ const Example6 = () => {
         <MultiCombobox
           label="Filter columns"
           variant="solid"
-          placeholder={`Filtered Columns (${selectedMoto.length})`}
+          renderPlaceHolder={() => <div>Filtered Columns ({selectedMoto.length})</div>}
           items={['Benelli', 'Ducati', 'BMW', 'Moto Guzzi', 'Piaggio']}
           onChange={updateSelectedMoto}
           value={selectedMoto}
@@ -239,7 +238,6 @@ const Example7 = () => {
               <AbstractButton
                 width="100%"
                 onClick={() => {
-                  console.log('hi');
                   clearSelectedItems();
                 }}
                 fontSize="x-small"

--- a/src/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.test.tsx
@@ -327,7 +327,7 @@ describe('MultiCombobox', () => {
     expect(queryAllByRole('tag')).toHaveLength(items.filter(i => i.category === 'Normal').length);
   });
 
-  it('renders a custom placeholder', async () => {
+  it('renders custom content', async () => {
     const ComboBox: React.FC<Partial<MultiComboboxProps<Item>>> = props => {
       const [selectedManufacturer, updateSelectedManufacturer] = React.useState<Item[]>([]);
 
@@ -338,7 +338,7 @@ describe('MultiCombobox', () => {
           value={selectedManufacturer}
           items={items}
           itemToString={item => item.value}
-          renderPlaceHolder={() => <>Custom Placeholder</>}
+          renderContent={() => <>Custom Placeholder</>}
           {...props}
         />
       );

--- a/src/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.test.tsx
@@ -50,7 +50,7 @@ describe('MultiCombobox', () => {
     fireClickAndMouseEvents(await getByText('Toyota'));
     expect(container).toMatchSnapshot();
     fireClickAndMouseEvents(await getByText('Ford'));
-    expect(await getByText('Clear All')).toBeInTheDocument();
+    expect(await getByText('Clear Selection')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 
@@ -98,12 +98,12 @@ describe('MultiCombobox', () => {
     fireClickAndMouseEvents(await getByText('Toyota'));
     fireClickAndMouseEvents(await getByText('Ford'));
     fireClickAndMouseEvents(await getByText('Mercedes'));
-    expect(await queryByText('Clear All')).not.toBeInTheDocument();
+    expect(await queryByText('Clear Selection')).not.toBeInTheDocument();
     fireClickAndMouseEvents(await getByText('Chevrolet'));
-    expect(await queryByText('Clear All')).toBeInTheDocument();
+    expect(await queryByText('Clear Selection')).toBeInTheDocument();
     fireClickAndMouseEvents(await getByText('Dodge'));
     expect(getAllByRole('tag')).toHaveLength(5);
-    fireClickAndMouseEvents(await getByText('Clear All'));
+    fireClickAndMouseEvents(await getByText('Clear Selection'));
     expect(queryAllByRole('tag')).toHaveLength(0);
   });
 
@@ -325,5 +325,26 @@ describe('MultiCombobox', () => {
 
     fireClickAndMouseEvents(getByText('Normal'));
     expect(queryAllByRole('tag')).toHaveLength(items.filter(i => i.category === 'Normal').length);
+  });
+
+  it('renders a custom placeholder', async () => {
+    const ComboBox: React.FC<Partial<MultiComboboxProps<Item>>> = props => {
+      const [selectedManufacturer, updateSelectedManufacturer] = React.useState<Item[]>([]);
+
+      return (
+        <MultiCombobox
+          label="Choose a car manufacturer"
+          onChange={updateSelectedManufacturer}
+          value={selectedManufacturer}
+          items={items}
+          itemToString={item => item.value}
+          renderPlaceHolder={() => <>Custom Placeholder</>}
+          {...props}
+        />
+      );
+    };
+
+    const { getByText } = renderWithTheme(<ComboBox />);
+    expect(getByText('Custom Placeholder'));
   });
 });

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -325,7 +325,7 @@ function MultiCombobox<Item>({
               >
                 <Flex as="ul" wrap="wrap" align="baseline" pl={3} pr={10} pt={itemsPt} pb="2px">
                   <>
-                    {renderPlaceHolder && Boolean(value.length)
+                    {renderPlaceHolder
                       ? renderPlaceHolder({ itemToString, removeItem })
                       : value.map(selectedItem => (
                           <Tag

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -11,6 +11,7 @@ import { typedMemo } from '../../utils/helpers';
 import Menu from '../utils/Menu';
 import AbstractButton from '../AbstractButton';
 import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
+import Icon from '../Icon';
 
 export type MultiComboboxProps<T> = {
   /** Callback when the selection changes */
@@ -364,22 +365,6 @@ function MultiCombobox<Item>({
                     </Box>
                   </>
                 </Flex>
-                {isOpen &&
-                  canClearAllAfter &&
-                  value.length >= canClearAllAfter &&
-                  (renderClearAll ? (
-                    renderClearAll(clearSelectedItems)
-                  ) : (
-                    <AbstractButton
-                      width="100%"
-                      py={1}
-                      backgroundColor="blue-400"
-                      fontSize="2x-small"
-                      onClick={clearSelectedItems}
-                    >
-                      Clear All
-                    </AbstractButton>
-                  ))}
 
                 <InputLabel
                   visuallyHidden={hideLabel}
@@ -417,6 +402,34 @@ function MultiCombobox<Item>({
               isOpen={isOpen && results.length > 0}
               {...getMenuProps()}
             >
+              {isOpen &&
+                canClearAllAfter &&
+                value.length >= canClearAllAfter &&
+                (renderClearAll ? (
+                  renderClearAll(clearSelectedItems)
+                ) : (
+                  <Box
+                    as="li"
+                    listStyle="none"
+                    backgroundColor="navyblue-350"
+                    position="sticky"
+                    top={0}
+                    zIndex={1}
+                  >
+                    <AbstractButton
+                      width="100%"
+                      onClick={clearSelectedItems}
+                      fontSize="x-small"
+                      color="teal-200"
+                      _hover={{ textDecoration: 'underline' }}
+                    >
+                      <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
+                        <Icon size="small" type="close-circle" />
+                        <Box as="span">Clear Selection</Box>
+                      </Flex>
+                    </AbstractButton>
+                  </Box>
+                ))}
               <ComboBoxItems
                 items={results}
                 disableItem={disableItem}

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -59,9 +59,6 @@ export type MultiComboboxProps<T> = {
   /** Whether the multi-combobox is required or not */
   required?: boolean;
 
-  /** Override the default clear all component.  Passes in the `clearSelectedItems` callback */
-  renderClearAll?: (clearSelectedItems: () => void) => React.ReactNode;
-
   /** Override the default placeholder.  Passes in the `clearSelectedItems` callback */
   renderPlaceHolder?: ({
     itemToString,
@@ -159,7 +156,6 @@ function MultiCombobox<Item>({
   canClearAllAfter,
   invalid,
   hidden,
-  renderClearAll,
   renderPlaceHolder,
   ...rest
 }: MultiComboboxProps<Item>): React.ReactElement<MultiComboboxProps<Item>> {
@@ -402,34 +398,29 @@ function MultiCombobox<Item>({
               isOpen={isOpen && results.length > 0}
               {...getMenuProps()}
             >
-              {isOpen &&
-                canClearAllAfter &&
-                value.length >= canClearAllAfter &&
-                (renderClearAll ? (
-                  renderClearAll(clearSelectedItems)
-                ) : (
-                  <Box
-                    as="li"
-                    listStyle="none"
-                    backgroundColor="navyblue-350"
-                    position="sticky"
-                    top={0}
-                    zIndex={1}
+              {isOpen && canClearAllAfter && value.length >= canClearAllAfter && (
+                <Box
+                  as="li"
+                  listStyle="none"
+                  backgroundColor="navyblue-350"
+                  position="sticky"
+                  top={0}
+                  zIndex={1}
+                >
+                  <AbstractButton
+                    width="100%"
+                    onClick={clearSelectedItems}
+                    fontSize="x-small"
+                    color="teal-200"
+                    _hover={{ textDecoration: 'underline' }}
                   >
-                    <AbstractButton
-                      width="100%"
-                      onClick={clearSelectedItems}
-                      fontSize="x-small"
-                      color="teal-200"
-                      _hover={{ textDecoration: 'underline' }}
-                    >
-                      <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
-                        <Icon size="small" type="close-circle" />
-                        <Box as="span">Clear Selection</Box>
-                      </Flex>
-                    </AbstractButton>
-                  </Box>
-                ))}
+                    <Flex as="span" align="center" spacing="6px" py="6px" px={4}>
+                      <Icon size="small" type="close-circle" />
+                      <Box as="span">Clear Selection</Box>
+                    </Flex>
+                  </AbstractButton>
+                </Box>
+              )}
               <ComboBoxItems
                 items={results}
                 disableItem={disableItem}

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -58,6 +58,12 @@ export type MultiComboboxProps<T> = {
   /** Whether the multi-combobox is required or not */
   required?: boolean;
 
+  /** Always show the placeholder, even when items are selected */
+  alwaysUsePlaceholder?: boolean;
+
+  /** Override the default clear all component.  Passes in the `clearSelectedItems` callback */
+  renderClearAll?: (clearSelectedItems: () => void) => React.ReactNode;
+
   /** Whether the multi-combobox is disabled or not */
   disabled?: boolean;
 
@@ -146,6 +152,8 @@ function MultiCombobox<Item>({
   canClearAllAfter,
   invalid,
   hidden,
+  alwaysUsePlaceholder,
+  renderClearAll,
   ...rest
 }: MultiComboboxProps<Item>): React.ReactElement<MultiComboboxProps<Item>> {
   const getVariant = React.useCallback(
@@ -225,7 +233,7 @@ function MultiCombobox<Item>({
           }).map(i => i.item);
         }
 
-        // We add 2 types of additional data to the input that is going to be renders:
+        // We add 2 types of additional data to the input that is going to be rendered:
         // 1. A handler for the `Delete` button, so that you can delete tokens with a single key
         // 3. When the combobox is not searchable, we make the input "behave" like a div. We
         // still want an input though for placeholder, spacings, etc.
@@ -311,16 +319,18 @@ function MultiCombobox<Item>({
               >
                 <Flex as="ul" wrap="wrap" align="baseline" pl={3} pr={10} pt={itemsPt} pb="2px">
                   <>
-                    {value.map(selectedItem => (
-                      <Tag
-                        as="li"
-                        key={itemToString(selectedItem)}
-                        m={1}
-                        onRemove={() => removeItem(selectedItem)}
-                      >
-                        {itemToString(selectedItem)}
-                      </Tag>
-                    ))}
+                    {alwaysUsePlaceholder && Boolean(value.length)
+                      ? placeholder
+                      : value.map(selectedItem => (
+                          <Tag
+                            as="li"
+                            key={itemToString(selectedItem)}
+                            m={1}
+                            onRemove={() => removeItem(selectedItem)}
+                          >
+                            {itemToString(selectedItem)}
+                          </Tag>
+                        ))}
                     <Box
                       as="li"
                       maxWidth="100%"
@@ -348,17 +358,22 @@ function MultiCombobox<Item>({
                     </Box>
                   </>
                 </Flex>
-                {isOpen && canClearAllAfter && value.length >= canClearAllAfter && (
-                  <AbstractButton
-                    width="100%"
-                    py={1}
-                    backgroundColor="blue-400"
-                    fontSize="2x-small"
-                    onClick={clearSelectedItems}
-                  >
-                    Clear All
-                  </AbstractButton>
-                )}
+                {isOpen &&
+                  canClearAllAfter &&
+                  value.length >= canClearAllAfter &&
+                  (renderClearAll ? (
+                    renderClearAll(clearSelectedItems)
+                  ) : (
+                    <AbstractButton
+                      width="100%"
+                      py={1}
+                      backgroundColor="blue-400"
+                      fontSize="2x-small"
+                      onClick={clearSelectedItems}
+                    >
+                      Clear All
+                    </AbstractButton>
+                  ))}
 
                 <InputLabel
                   visuallyHidden={hideLabel}

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -13,6 +13,12 @@ import AbstractButton from '../AbstractButton';
 import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
 import Icon from '../Icon';
 
+type DefaultContentProps<T> = {
+  itemToString: (item: T) => string;
+  removeItem: (item: T) => void;
+  value: T[];
+};
+
 export type MultiComboboxProps<T> = {
   /** Callback when the selection changes */
   onChange: (value: T[]) => void;
@@ -59,14 +65,8 @@ export type MultiComboboxProps<T> = {
   /** Whether the multi-combobox is required or not */
   required?: boolean;
 
-  /** Override the default placeholder.  Passes in the `clearSelectedItems` callback */
-  renderPlaceHolder?: ({
-    itemToString,
-    removeItem,
-  }: {
-    itemToString: (item: T) => string;
-    removeItem: (item: T) => void;
-  }) => React.ReactNode;
+  /** Override the default tag content */
+  renderContent?: ({ itemToString, removeItem, value }: DefaultContentProps<T>) => React.ReactNode;
 
   /** Whether the multi-combobox is disabled or not */
   disabled?: boolean;
@@ -132,6 +132,14 @@ const stateReducer = (state: DownshiftState<any>, changes: StateChangeOptions<an
   }
 };
 
+function DefaultContent<T>({ value, itemToString, removeItem }: DefaultContentProps<T>) {
+  return value.map(selectedItem => (
+    <Tag as="li" key={itemToString(selectedItem)} m={1} onRemove={() => removeItem(selectedItem)}>
+      {itemToString(selectedItem)}
+    </Tag>
+  ));
+}
+
 /**
  * A simple MultiCombobox can be thought of as a typical `<select>` component. Whenever you would
  * use a normal select, you should now pass the `<MultiCombobox>` component.
@@ -156,7 +164,7 @@ function MultiCombobox<Item>({
   canClearAllAfter,
   invalid,
   hidden,
-  renderPlaceHolder,
+  renderContent = DefaultContent,
   ...rest
 }: MultiComboboxProps<Item>): React.ReactElement<MultiComboboxProps<Item>> {
   const getVariant = React.useCallback(
@@ -322,18 +330,7 @@ function MultiCombobox<Item>({
               >
                 <Flex as="ul" wrap="wrap" align="baseline" pl={3} pr={10} pt={itemsPt} pb="2px">
                   <>
-                    {renderPlaceHolder
-                      ? renderPlaceHolder({ itemToString, removeItem })
-                      : value.map(selectedItem => (
-                          <Tag
-                            as="li"
-                            key={itemToString(selectedItem)}
-                            m={1}
-                            onRemove={() => removeItem(selectedItem)}
-                          >
-                            {itemToString(selectedItem)}
-                          </Tag>
-                        ))}
+                    {renderContent({ itemToString, removeItem, value })}
                     <Box
                       as="li"
                       maxWidth="100%"

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -64,6 +64,15 @@ export type MultiComboboxProps<T> = {
   /** Override the default clear all component.  Passes in the `clearSelectedItems` callback */
   renderClearAll?: (clearSelectedItems: () => void) => React.ReactNode;
 
+  /** Override the default placeholder.  Passes in the `clearSelectedItems` callback */
+  renderPlaceHolder?: ({
+    itemToString,
+    removeItem,
+  }: {
+    itemToString: (item: T) => string;
+    removeItem: (item: T) => void;
+  }) => React.ReactNode;
+
   /** Whether the multi-combobox is disabled or not */
   disabled?: boolean;
 
@@ -152,8 +161,8 @@ function MultiCombobox<Item>({
   canClearAllAfter,
   invalid,
   hidden,
-  alwaysUsePlaceholder,
   renderClearAll,
+  renderPlaceHolder,
   ...rest
 }: MultiComboboxProps<Item>): React.ReactElement<MultiComboboxProps<Item>> {
   const getVariant = React.useCallback(
@@ -319,8 +328,8 @@ function MultiCombobox<Item>({
               >
                 <Flex as="ul" wrap="wrap" align="baseline" pl={3} pr={10} pt={itemsPt} pb="2px">
                   <>
-                    {alwaysUsePlaceholder && Boolean(value.length)
-                      ? placeholder
+                    {renderPlaceHolder && Boolean(value.length)
+                      ? renderPlaceHolder({ itemToString, removeItem })
                       : value.map(selectedItem => (
                           <Tag
                             as="li"

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -58,9 +58,6 @@ export type MultiComboboxProps<T> = {
   /** Whether the multi-combobox is required or not */
   required?: boolean;
 
-  /** Always show the placeholder, even when items are selected */
-  alwaysUsePlaceholder?: boolean;
-
   /** Override the default clear all component.  Passes in the `clearSelectedItems` callback */
   renderClearAll?: (clearSelectedItems: () => void) => React.ReactNode;
 

--- a/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
+++ b/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
@@ -830,7 +830,7 @@ exports[`MultiCombobox renders with clear all option 1`] = `
 `;
 
 exports[`MultiCombobox renders with clear all option 2`] = `
-.pounce-15 {
+.pounce-14 {
   position: relative;
 }
 
@@ -936,7 +936,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   border-radius: 4px;
 }
 
-.pounce-13 {
+.pounce-12 {
   outline: none;
   line-height: 1;
   border-radius: 4px;
@@ -951,11 +951,11 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   transition: all 0.1s linear;
 }
 
-.pounce-13:focus {
+.pounce-12:focus {
   background-color: rgba(255,255,255,0.1);
 }
 
-.pounce-12 {
+.pounce-11 {
   display: inline-block;
   vertical-align: sub;
   -webkit-flex-shrink: 0;
@@ -968,7 +968,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
 
 
 
-.pounce-11 {
+.pounce-10 {
   min-height: 47px;
   position: relative;
   border: 1px solid;
@@ -979,20 +979,20 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   border-color: #23344E;
 }
 
-.pounce-11:hover {
+.pounce-10:hover {
   border-color: #0081C5;
 }
 
-.pounce-11:focus-within {
+.pounce-10:focus-within {
   border-color: #0081C5;
 }
 
-.pounce-11:focus-within span {
+.pounce-10:focus-within span {
   opacity: 1;
   visibility: visible;
 }
 
-.pounce-11:focus-within label {
+.pounce-10:focus-within label {
   font-weight: 500;
   -webkit-transform: translate(6px, 4px) scale(0.65);
   -moz-transform: translate(6px, 4px) scale(0.65);
@@ -1000,7 +1000,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   transform: translate(6px, 4px) scale(0.65);
 }
 
-.pounce-10 {
+.pounce-9 {
   pointer-events: none;
   font-size: 0.875rem;
   padding-left: 16px;
@@ -1019,7 +1019,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   font-weight: 500;
 }
 
-.pounce-14 {
+.pounce-13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1040,7 +1040,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   pointer-events: auto;
 }
 
-.pounce-25 {
+.pounce-29 {
   margin-top: -3px;
   border: 1px solid;
   border-left-color: #0081C5;
@@ -1057,7 +1057,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   overflow: auto;
 }
 
-.pounce-19 {
+.pounce-23 {
   cursor: pointer;
   font-size: 0.875rem;
   padding-top: 16px;
@@ -1071,12 +1071,12 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   word-break: break-all;
 }
 
-.pounce-19[aria-selected=true],
-[data-selected]>.pounce-19 {
+.pounce-23[aria-selected=true],
+[data-selected]>.pounce-23 {
   background-color: #23344E;
 }
 
-.pounce-19::after {
+.pounce-23::after {
   content: "";
   border: 1px solid;
   border-color: #86A3C3;
@@ -1145,7 +1145,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   color: currentColor;
 }
 
-.pounce-17 {
+.pounce-21 {
   cursor: pointer;
   font-size: 0.875rem;
   padding-top: 16px;
@@ -1159,12 +1159,12 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   word-break: break-all;
 }
 
-.pounce-17[aria-selected=true],
-[data-selected]>.pounce-17 {
+.pounce-21[aria-selected=true],
+[data-selected]>.pounce-21 {
   background-color: #23344E;
 }
 
-.pounce-17::after {
+.pounce-21::after {
   content: url( 'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 20 18" fill="white"><path d="M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42L7 14.17z" /></svg>' );
   border: 1px solid;
   border-color: #0081C5;
@@ -1190,18 +1190,59 @@ exports[`MultiCombobox renders with clear all option 2`] = `
   margin: auto 0;
 }
 
-.pounce-9 {
+.pounce-20 {
+  background-color: #30415C;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.pounce-19 {
   width: 100%;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  background-color: #0081C5;
-  font-size: 0.563rem;
+  font-size: 0.625rem;
+  color: #56E3C9;
   cursor: pointer;
-  color: #F6F6F6;
   -webkit-text-decoration: none;
   text-decoration: none;
+  background-color: transparent;
   -webkit-transition: all 0.1s linear;
   transition: all 0.1s linear;
+}
+
+.pounce-19:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.pounce-18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.pounce-18>*:not(:last-child) {
+  margin-right: 6px;
+}
+
+.pounce-16 {
+  display: inline-block;
+  vertical-align: sub;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: currentColor;
 }
 
 <div>
@@ -1210,15 +1251,15 @@ exports[`MultiCombobox renders with clear all option 2`] = `
     aria-haspopup="listbox"
     aria-labelledby="downshift-2-label"
     aria-owns="downshift-2-menu"
-    class="pounce-15"
+    class="pounce-14"
     role="combobox"
   >
     <div
-      class="pounce-15"
+      class="pounce-14"
     >
       <div
         aria-disabled="false"
-        class="pounce-11"
+        class="pounce-10"
       >
         <ul
           class="pounce-8"
@@ -1285,14 +1326,8 @@ exports[`MultiCombobox renders with clear all option 2`] = `
             />
           </li>
         </ul>
-        <button
-          class="pounce-9"
-          type="button"
-        >
-          Clear All
-        </button>
         <label
-          class="pounce-10"
+          class="pounce-9"
           for="downshift-2-input"
           id="downshift-2-label"
         >
@@ -1300,17 +1335,17 @@ exports[`MultiCombobox renders with clear all option 2`] = `
         </label>
       </div>
       <div
-        class="pounce-14"
+        class="pounce-13"
       >
         <button
           aria-label="Toggle Menu"
           aria-pressed="false"
-          class="pounce-13"
+          class="pounce-12"
           tabindex="-1"
           type="button"
         >
           <svg
-            class="pounce-12"
+            class="pounce-11"
             role="presentation"
             viewBox="0 0 24 24"
           >
@@ -1323,21 +1358,52 @@ exports[`MultiCombobox renders with clear all option 2`] = `
     </div>
     <ul
       aria-labelledby="downshift-2-label"
-      class="pounce-16"
+      class="pounce-15"
       id="downshift-2-menu"
       role="listbox"
     />
     <ul
       aria-labelledby="downshift-2-label"
-      class="pounce-25"
+      class="pounce-29"
       id="downshift-2-menu"
       role="listbox"
       style="transform: scale(1, 1); opacity: 1;"
     >
       <li
+        class="pounce-20"
+      >
+        <button
+          class="pounce-19"
+          type="button"
+        >
+          <span
+            class="pounce-18"
+          >
+            <svg
+              class="pounce-16"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm2.828 5.757L12 10.587l-2.828-2.83-1.415 1.415L10.587 12l-2.83 2.828 1.415 1.415L12 13.414l2.828 2.829 1.415-1.415L13.414 12l2.829-2.828-1.415-1.415z"
+              />
+            </svg>
+            <span
+              class="pounce-15"
+            >
+              Clear Selection
+            </span>
+          </span>
+        </button>
+      </li>
+      <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-17"
+        class="pounce-21"
         id="downshift-2-item-0"
         role="option"
       >
@@ -1346,7 +1412,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-17"
+        class="pounce-21"
         id="downshift-2-item-1"
         role="option"
       >
@@ -1355,7 +1421,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-2"
         role="option"
       >
@@ -1364,7 +1430,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-3"
         role="option"
       >
@@ -1373,7 +1439,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-4"
         role="option"
       >
@@ -1382,7 +1448,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-5"
         role="option"
       >
@@ -1391,7 +1457,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-6"
         role="option"
       >
@@ -1400,7 +1466,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
       <li
         aria-disabled="false"
         aria-selected="false"
-        class="pounce-19"
+        class="pounce-23"
         id="downshift-2-item-7"
         role="option"
       >


### PR DESCRIPTION
### Background

Looking to make an alteration to the `MultiComboBox` that matches this figma example - https://www.figma.com/proto/m8HKEVhIUX0qGaIB0geBVx/Data-Explorer-V2?page-id=0%3A1&node-id=87%3A6959&viewport=352%2C48%2C0.31&scaling=min-zoom&starting-point-node-id=84%3A5970

### Changes

- Added `renderPlaceHolder` prop that allows you to pass in a custom placeholder
- Changed default `Clear All` banner button to the new design with the pleasant green icon 
<img width="371" alt="image" src="https://user-images.githubusercontent.com/16771592/165389862-227012a5-3a91-4f0c-9797-ef42d3622a11.png">


### Testing

- Added one test to verify custom placeholder passes properly
- Updated snapshots