### PR TITLE
fix: remove 'clear selection' on TimePicker

### DIFF
--- a/src/components/DateInput/TimePicker.tsx
+++ b/src/components/DateInput/TimePicker.tsx
@@ -92,6 +92,7 @@ const TimePicker: React.FC<TimePickerProps> = ({
         hideLabel
         items={hourItems}
         value={hour}
+        showClearSelectionControl={false}
       />
 
       <Combobox
@@ -102,6 +103,7 @@ const TimePicker: React.FC<TimePickerProps> = ({
         hideLabel
         items={minsItems}
         value={min}
+        showClearSelectionControl={false}
       />
 
       {is12Hours && (
@@ -112,6 +114,7 @@ const TimePicker: React.FC<TimePickerProps> = ({
           hideLabel
           items={periodItems}
           value={period}
+          showClearSelectionControl={false}
         />
       )}
     </Flex>


### PR DESCRIPTION
### Background

High level overview here

### Changes

- remove 'clear selection' for any instance of `<TimePicker />`

### Testing

- Testing steps

### Visuals

Component that is updated - <img width="583" alt="image" src="https://user-images.githubusercontent.com/16771592/165838825-414afde5-6ee9-4845-ba17-49c6b7dc5646.png">

Before:
<img width="331" alt="image" src="https://user-images.githubusercontent.com/16771592/165839010-6fd60be5-5b85-4509-b136-cd69b5370653.png">


After:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/16771592/165838930-607a3f18-7d90-4bb7-bdea-e9eb78ed637f.png">



