### PR TITLE
feat(tooltip): allow position to be set

### DIFF
--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -29,3 +29,22 @@ Content can be anything as well:
   <Box>Hover me to see a pretty icon</Box>
 </Tooltip>
 ```
+
+The default right-side positioning can be customized:
+
+```typescript jsx
+// Center the tooltip, but collisions will win
+const centered = (triggerRect, tooltipRect) => {
+  const triggerCenter = triggerRect.left + triggerRect.width / 2;
+  const left = triggerCenter - tooltipRect.width / 2;
+  const maxLeft = window.innerWidth - tooltipRect.width - 2;
+  return {
+    left: Math.min(Math.max(2, left), maxLeft) + window.scrollX,
+    top: triggerRect.bottom + 8 + window.scrollY,
+  };
+};
+
+<Tooltip content="hello!" position={centered}>
+  <Box>Hover me for a greeting</Box>
+</Tooltip>;
+```

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ export interface TooltipProps {
   content: string | React.ReactElement;
 
   /** The position of the tooltip relative to the content */
-  position: Position;
+  position?: Position;
 
   /** @ignore */
   children: React.ReactElement;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTooltip, TooltipPopup } from '@reach/tooltip';
+import { Position } from '@reach/popover';
 import { useTransition, animated } from 'react-spring';
 import { positionRight } from './utils';
 import Box from '../Box';
@@ -10,13 +11,16 @@ export interface TooltipProps {
   /** The string or HTML that the tooltip will show*/
   content: string | React.ReactElement;
 
+  /** The position of the tooltip relative to the content */
+  position: Position;
+
   /** @ignore */
   children: React.ReactElement;
 }
 
 /** A tooltip is a helper that shows some helping text when hovering or clicking something */
 const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
-  { content, children },
+  { content, position = positionRight, children },
   ref
 ) {
   const [trigger, { triggerRect }, isVisible] = useTooltip();
@@ -44,7 +48,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
               key={key}
               style={{ ...styles, zIndex: 11, position: 'absolute' }}
               ref={ref}
-              position={positionRight}
+              position={position}
               as={'div'}
               label={
                 <Box


### PR DESCRIPTION
### Background

It would be nice to be able to customize the tooltip position.

### Changes

Let consumers override `position`. Default to previous value.

### Testing

- `npm test`
