### PR TITLE
fix: keep table z-indices from polluting global z-index space

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -45,7 +45,17 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
   );
   return (
     <TableContext.Provider value={contextValue}>
-      <Box as="table" tableLayout={layout} ref={ref} width={1} {...rest} />
+      <Box
+        as="table"
+        tableLayout={layout}
+        ref={ref}
+        width={1}
+        // Make a new "stacking context" so that any absolute- / sticky-positioned
+        // items (like header rows) will not pollute the global z-index space.
+        position="relative"
+        zIndex={0}
+        {...rest}
+      />
     </TableContext.Provider>
   );
 });


### PR DESCRIPTION
### Background

Noticed the following code while working in Data Explorer

This is the table code itself for the results table, note the `zIndex: 1001`

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/20060118/172714773-a25f3107-6ab2-44cb-ba36-c6f0a76c9956.png">

This is another component _not within the table_, not `zIndex: 1002`:

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/20060118/172714917-fbbe35d4-24c9-425e-a173-c10968df1f25.png">

This component _outside of the table_ should not need to be aware of the z-indexing _inside_ the table. Rather, the table itself probably needs to create a new stacking context so that other parts of the app can have independent z-indexing.

If need be, this can be done on individual tables in `panther-enterprise` by wrapping a table with a `Box` creating the new stacking context. But I think the z-index bleeding outside is serious enough that we should do this in the `Table` itself. Hence this PR.

### Changes

- Fix z-indexing inside of table forcing other components outside of the table to accomodate.

