### PR TITLE
Add onBlur on combobox and multi combobox fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,6 +3730,26 @@
         "@testing-library/dom": "^7.17.1"
       }
     },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
+          "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@tippyjs/react": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@commitlint/config-conventional": "^10.0.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
+    "@testing-library/user-event": "^13.5.0",
     "@types/jest-axe": "^3.5.0",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",

--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithTheme, fireClickAndMouseEvents } from 'test-utils';
 import React from 'react';
 import Combobox, { ComboboxProps } from './index';
+import userEvent from '@testing-library/user-event';
 
 type Item = { value: string; category: string };
 
@@ -61,5 +62,18 @@ describe('Combobox', () => {
 
     fireClickAndMouseEvents(clearSelectionButton);
     expect(selectionInput).not.toHaveValue();
+  });
+
+  it('fires onblur event when the input focus is lost', async () => {
+    const mock = jest.fn();
+    const { getByPlaceholderText } = renderWithTheme(
+      <>
+        <ControlledCombobox onBlur={mock} />
+        <input placeholder="another input" />
+      </>
+    );
+    userEvent.click(getByPlaceholderText('Select manufacturer'));
+    userEvent.click(getByPlaceholderText('another input'));
+    expect(mock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -185,6 +185,7 @@ function Combobox<Item>({
             cursor: 'pointer',
             onMouseDown: toggleMenu,
             onFocus: openMenu,
+            onBlur: onBlur,
             readOnly: true,
           }),
           ...(searchable && {

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -2,17 +2,17 @@
 import React from 'react';
 import Downshift from 'downshift';
 import { filter as fuzzySearch } from 'fuzzaldrin';
-import Box from '../Box';
+import Box, { NativeAttributes } from '../Box';
 import Flex from '../Flex';
 import IconButton from '../IconButton';
 import AbstractButton from '../AbstractButton';
-import { InputControl, InputElement, InputLabel, InputElementProps } from '../utils/Input';
+import { InputControl, InputElement, InputLabel } from '../utils/Input';
 import { typedMemo } from '../../utils/helpers';
 import Menu from '../utils/Menu';
 import ComboBoxItems from '../utils/ComboBoxItems/ComboBoxItems';
 import Icon from '../Icon';
 
-export type ComboboxProps<T> = {
+export type ComboboxProps<T> = Omit<NativeAttributes<'input'>, 'value' | 'onChange'> & {
   /** Callback when the selection changes */
   onChange: (value: T | null) => void;
 
@@ -92,6 +92,7 @@ export type ComboboxProps<T> = {
  */
 function Combobox<Item>({
   onChange,
+  onBlur,
   value,
   items,
   variant = 'outline',
@@ -194,9 +195,12 @@ function Combobox<Item>({
               openMenu();
               setInputValue('');
             },
-            onBlur: () => {
+            onBlur: (e: React.FocusEvent<HTMLInputElement>): void => {
               closeMenu();
               setInputValue(safeItemToString(value));
+              if (onBlur) {
+                onBlur(e);
+              }
             },
           }),
         };
@@ -217,7 +221,7 @@ function Combobox<Item>({
                   truncated
                   standalone={hideLabel}
                   pr={8} /* account for absolute position of caret */
-                  {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
+                  {...getInputProps(additionalInputProps)}
                 />
 
                 <InputLabel visuallyHidden={hideLabel} raised={value != null} {...getLabelProps()}>

--- a/src/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.test.tsx
@@ -1,6 +1,7 @@
 import { renderWithTheme, fireClickAndMouseEvents, fireEvent, within } from 'test-utils';
 import React from 'react';
 import MultiCombobox, { MultiComboboxProps } from './index';
+import userEvent from '@testing-library/user-event';
 
 type Item = { value: string; category: string };
 
@@ -346,5 +347,18 @@ describe('MultiCombobox', () => {
 
     const { getByText } = renderWithTheme(<ComboBox />);
     expect(getByText('Custom Placeholder'));
+  });
+
+  it('fires onblur event when the input focus is lost', async () => {
+    const mock = jest.fn();
+    const { getByPlaceholderText } = renderWithTheme(
+      <>
+        <ControlledMultiCombobox searchable canClearAllAfter={2} onBlur={mock} />
+        <input placeholder="another input" />
+      </>
+    );
+    userEvent.click(getByPlaceholderText('Select manufacturers'));
+    userEvent.click(getByPlaceholderText('another input'));
+    expect(mock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import { filter as fuzzySearch } from 'fuzzaldrin';
-import Box from '../Box';
+import Box, { NativeAttributes } from '../Box';
 import IconButton from '../IconButton';
 import Flex from '../Flex';
-import { InputControl, InputLabel, InputElement, InputElementProps } from '../utils/Input';
+import { InputControl, InputLabel, InputElement } from '../utils/Input';
 import Tag from './Tag';
 import { typedMemo } from '../../utils/helpers';
 import Menu from '../utils/Menu';
@@ -20,7 +20,7 @@ type DefaultContentProps<T> = {
   isOpen: boolean;
 };
 
-export type MultiComboboxProps<T> = {
+export type MultiComboboxProps<T> = Omit<NativeAttributes<'input'>, 'value' | 'onChange'> & {
   /** Callback when the selection changes */
   onChange: (value: T[]) => void;
 
@@ -152,6 +152,7 @@ function DefaultContent<T>({ value, itemToString, removeItem }: DefaultContentPr
  */
 function MultiCombobox<Item>({
   onChange,
+  onBlur,
   value,
   variant = 'outline',
   items,
@@ -294,10 +295,13 @@ function MultiCombobox<Item>({
               }
             }
           },
-          onBlur: () => {
+          onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
             const processedUserValue = processUserValue(inputValue);
             if (allowAdditions && validateUserValue(processedUserValue)) {
               selectItem((processedUserValue as unknown) as Item, { inputValue: '' });
+            }
+            if (onBlur) {
+              onBlur(e);
             }
           },
           onPaste: (e: React.ClipboardEvent<HTMLInputElement>) => {
@@ -359,7 +363,7 @@ function MultiCombobox<Item>({
                       <InputElement
                         type="text"
                         standalone={hideLabel}
-                        {...(getInputProps(additionalInputProps) as Omit<InputElementProps, 'ref'>)}
+                        {...getInputProps(additionalInputProps)}
                       />
                     </Box>
                   </>


### PR DESCRIPTION
### Background

Up until now, our Combobox & MultiCombobox components were not propagating the onBlur events. This PR adds support to pass an onBlur callback that will be used by the input element of the combo boxes. This in turn will allow us to determine if a combobox input is touched or not so we can display Formik errors on our Forms  only if a field is touched.

### Changes

- Handle Focus/Blur events on comboboxes

### Testing

- Testing steps
none yet :) 