### PR TITLE
fix: type error in MultiComboBox

### DIFF
--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -264,7 +264,10 @@ function MultiCombobox<Item>({
             placeholder: !value.length ? placeholder : '',
           }),
           ...(searchable && {
-            placeholder: (hideLabel && value.length && !isOpen) || value.length ? '' : placeholder,
+            placeholder:
+              (hideLabel && value && value.length && !isOpen) || (value && value.length)
+                ? ''
+                : placeholder,
             p: isOpen ? 1 : null,
           }),
           position: 'absolute',


### PR DESCRIPTION
### Background

A Sentry issue was triggered indicating a TypeError in the MultiComboBox:
<img width="800" alt="Screen Shot 2022-08-05 at 11 54 02 AM" src="https://user-images.githubusercontent.com/4212239/183133642-4255efff-da57-4940-a720-722fb5cb420d.png">

[Link to Sentry Issue](https://sentry.io/organizations/panther-labs/issues/3472972234/?project=5699727&referrer=assigned_activity-email)

### Changes

- Add check for `value` before checking for `value.length`

### Testing

- Verify placeholder text for searchable MultiComboBox still populates as expected.

https://user-images.githubusercontent.com/4212239/183134256-b3d28a45-fbac-4835-ad4e-5025e9c1d441.mov


