### PR TITLE
feat: Add "expand" icon

### DIFF
--- a/src/theme/icons.tsx
+++ b/src/theme/icons.tsx
@@ -277,11 +277,11 @@ const icons = {
   expand: {
     path: (
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
-        d="M19 5V11H17V8.327L8.328 17H11V19H5V13H7L6.999 15.5L15.499 7H13V5H19Z" fill="#FEFEFE"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M19 5V11H17V8.327L8.328 17H11V19H5V13H7L6.999 15.5L15.499 7H13V5H19Z"
       />
-    )
+    ),
   },
   history: {
     path: (

--- a/src/theme/icons.tsx
+++ b/src/theme/icons.tsx
@@ -274,6 +274,15 @@ const icons = {
   download: {
     path: <path d="M16 13H13V3H11V13H8L12 17L16 13ZM4 19V21H20V19H4Z" />,
   },
+  expand: {
+    path: (
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M19 5V11H17V8.327L8.328 17H11V19H5V13H7L6.999 15.5L15.499 7H13V5H19Z" fill="#FEFEFE"
+      />
+    )
+  },
   history: {
     path: (
       <React.Fragment>


### PR DESCRIPTION
### Background

This PR adds the missing "expand" icon found in the Pounce design system in [Figma](https://www.figma.com/file/xJGJA3FyFcamwsjFd9rLIT/Pounce-DS-V1.0?node-id=15%3A59)

### Changes

- Adds missing "expand" icon SVG path to icons.tsx

### Testing

- start app locally using `npm run start`
- navigate to http://localhost:9000/#/Icon
- search for "expand"
- ensure the "expand" icon is visible
