### PR TITLE
[Feat] New `backgroundOpacity` prop & updated background on `ProgressBar`

### DIFF
--- a/src/components/Box/Box.test.tsx
+++ b/src/components/Box/Box.test.tsx
@@ -12,6 +12,19 @@ describe('Box', () => {
     const { container } = await render(<Box truncated />);
     expect(container).toMatchSnapshot();
   });
+
+  it('allows specifying an opacity for the background color', async () => {
+    const { container } = await render(
+      <React.Fragment>
+        <Box backgroundColor="white" backgroundOpacity="0.5" />
+        <Box backgroundColor="white" backgroundOpacity={0.5} />
+        <Box backgroundColor="white" backgroundOpacity="50" />
+        <Box backgroundColor="white" backgroundOpacity={50} />
+      </React.Fragment>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it('allows styling on demand', async () => {
     const { container } = await render(
       <Box color="black" background="red" textTransform="uppercase" />

--- a/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Box allows specifying an opacity for the background color 1`] = `
+.pounce-0 {
+  background-color: white;
+  background-color: rgba(255,255,255,0.5);
+}
+
+<div>
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+</div>
+`;
+
 exports[`Box allows styling on demand 1`] = `
 .pounce-0 {
   color: black;

--- a/src/components/ProgressBar/ProgressBar.mdx
+++ b/src/components/ProgressBar/ProgressBar.mdx
@@ -4,18 +4,18 @@ needs to complete or to denote that something is not properly ready yet
 A ProgressBar can have different colors:
 
 ```typescript jsx
-<Box width={1}>
-  <Box mb={6}>
-    <ProgressBar color="blue-400" progress={0.6} />
-  </Box>
-  <Box>
-    <ProgressBar color="red-300" progress={0.9} />
-  </Box>
-</Box>
+<Flex direction="column" spacing={6} width={1}>
+  <ProgressBar color="blue-400" progress={0.4} />
+  <ProgressBar color="teal-400" progress={0.6} />
+</Flex>
 ```
 
 A ProgressBar can have different thickness:
 
 ```typescript jsx
-<ProgressBar color="blue-400" thickness={2} progress={0.6} />
+<Flex direction="column" spacing={6} width={1}>
+  <ProgressBar color="blue-400" thickness={4} progress={0.4} />
+  <ProgressBar color="teal-400" thickness={6} progress={0.6} />
+  <ProgressBar color="red-400" thickness={8} progress={0.8} />
+</Flex>
 ```

--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'test-utils';
+import ProgressBar from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders', async () => {
+    const { container } = await render(
+      <React.Fragment>
+        <ProgressBar progress={0.5} />
+        <ProgressBar progress={0.5} thickness={10} />
+        <ProgressBar progress={0.5} color="teal-400" />
+      </React.Fragment>
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -16,7 +16,13 @@ export interface ProgressBarProps {
 const ProgressBar: React.FC<ProgressBarProps> = ({ progress, thickness = 5, color }) => {
   return (
     <Box width={1} position="relative">
-      <Box height={thickness} bg="navyblue-300" borderRadius="pill" zIndex={0} />
+      <Box
+        height={thickness}
+        backgroundColor="white"
+        backgroundOpacity={0.1}
+        borderRadius="pill"
+        zIndex={0}
+      />
       <Box
         position="absolute"
         borderRadius="pill"

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressBar renders 1`] = `
+.pounce-2 {
+  width: 100%;
+  position: relative;
+}
+
+.pounce-0 {
+  height: 5px;
+  background-color: white;
+  border-radius: pill;
+  z-index: 0;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-1 {
+  position: absolute;
+  border-radius: pill;
+  bottom: 0;
+  height: 5px;
+  width: 50%;
+  -webkit-transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+}
+
+.pounce-3 {
+  height: 10px;
+  background-color: white;
+  border-radius: pill;
+  z-index: 0;
+  background-color: rgba(255,255,255,0.1);
+}
+
+.pounce-4 {
+  position: absolute;
+  border-radius: pill;
+  bottom: 0;
+  height: 10px;
+  width: 50%;
+  -webkit-transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+}
+
+.pounce-7 {
+  position: absolute;
+  border-radius: pill;
+  bottom: 0;
+  height: 5px;
+  width: 50%;
+  background-color: teal-400;
+  -webkit-transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,background-color 100ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+}
+
+<div>
+  <div
+    class="pounce-2"
+  >
+    <div
+      class="pounce-0"
+    />
+    <div
+      class="pounce-1"
+    />
+  </div>
+  <div
+    class="pounce-2"
+  >
+    <div
+      class="pounce-3"
+    />
+    <div
+      class="pounce-4"
+    />
+  </div>
+  <div
+    class="pounce-2"
+  >
+    <div
+      class="pounce-0"
+    />
+    <div
+      class="pounce-7"
+    />
+  </div>
+</div>
+`;

--- a/src/system/styled.ts
+++ b/src/system/styled.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { shouldForwardProp } from './shouldForwardProp';
 import { stylingProps, SystemProps } from './system';
 import { pseudoProps } from './pseudo';
-import { sxProp, truncateProp, visuallyHiddenProp } from './utility';
+import { backgroundOpacityProp, sxProp, truncateProp, visuallyHiddenProp } from './utility';
 
 export type NativeAttributes<El extends React.ElementType> = Omit<
   React.ComponentPropsWithRef<El>,
@@ -21,5 +21,6 @@ export const pounce = <T extends keyof JSX.IntrinsicElements>(tag: T) =>
   ${pseudoProps}
   ${sxProp}
   ${truncateProp}
+  ${backgroundOpacityProp}
   ${visuallyHiddenProp}
 ` as React.FC<PounceComponentProps<T>>;

--- a/src/system/utility.ts
+++ b/src/system/utility.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import css, { SystemCssProperties } from '@styled-system/css';
 import { StylingProps } from './system';
+import { addOpacity } from '../utils/helpers';
+import colors from '../theme/colors';
 
 export const truncateProp = ({ truncated }: any): any => {
   if (truncated) {
@@ -27,6 +29,27 @@ export const visuallyHiddenProp = ({ visuallyHidden }: any): any => {
   }
 };
 
+export const backgroundOpacityProp = ({
+  backgroundOpacity,
+  backgroundColor,
+}: {
+  backgroundOpacity: number | string;
+  backgroundColor: keyof typeof colors;
+}): any => {
+  if (backgroundOpacity) {
+    // As the value of `backgroundOpacity` we want to be able to parse a lot of alternatives such as: 0.5, "0.5", 50, "50"
+    // Obviously the user can still add values such as "110" or "200", but we can't do much there
+    let bgOpacity =
+      typeof backgroundOpacity === 'string' ? Number(backgroundOpacity) : backgroundOpacity;
+    bgOpacity = bgOpacity > 1 ? bgOpacity / 100 : bgOpacity;
+
+    const bgColor = colors[backgroundColor] ?? colors.inherit;
+    return {
+      backgroundColor: addOpacity(bgColor, bgOpacity),
+    };
+  }
+};
+
 export type SxProp = StylingProps | { [cssSelector: string]: SxProp | undefined };
 export const sxProp = (props: any) => css(props.sx as SystemCssProperties)(props);
 
@@ -39,4 +62,7 @@ export type UtilityProps = {
 
   /** Makes the component invisible to the eye, but still readable by screen readers */
   visuallyHidden?: boolean;
+
+  /** Adds an opacity to the existing `backgroundColor` */
+  backgroundOpacity?: string | number;
 };


### PR DESCRIPTION
### Background

This PR adds support for a new prop, available to all components named `backgroundOpacity`. 

This prop requires a sibling value of `backgroundColor` in order to work, so specifying a `backgroundOpacity` will only work if `backgroundColor` is also defined on the same component

Similar to how [Tailwind](https://tailwindcss.com/) implements it, we cannot rely on HTML element style parsing to "figure out" what background color an element holds. This is not only hard, but incurs a performance hit. 

### Usage

```tsx
<>
  <Box backgroundColor="red-100" backgroundOpacity={50} /> // equivalent to 50%
  <Box backgroundColor="red-100" backgroundOpacity={0.5} /> // equivalent to 50%
  <Box backgroundColor="red-100" backgroundOpacity={100} /> // equivalent to 100%
  <Box backgroundColor="red-100" backgroundOpacity={1} /> // equivalent to 100%
<>
```

### Screenshots

<img width="1054" alt="Screenshot 2022-08-24 at 5 02 15 PM" src="https://user-images.githubusercontent.com/10436045/186438621-cf75ccc4-6fbc-457d-a2dd-53eeeb37d511.png">

### Changes

- Add new prop
- Add snapshots tests for new prop

### Testing

- Snapshot
- Manually
