### PR TITLE
feat: add `borderOpacity` prop

### DIFF
--- a/src/components/Box/Box.test.tsx
+++ b/src/components/Box/Box.test.tsx
@@ -25,6 +25,18 @@ describe('Box', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('allows specifying an opacity for the border color', async () => {
+    const { container } = await render(
+      <React.Fragment>
+        <Box border="1px solid" borderColor="white" borderOpacity="0.5" />
+        <Box border="1px solid" borderColor="white" borderOpacity={0.5} />
+        <Box border="1px solid" borderColor="white" borderOpacity="50" />
+        <Box border="1px solid" borderColor="white" borderOpacity={50} />
+      </React.Fragment>
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it('allows styling on demand', async () => {
     const { container } = await render(
       <Box color="black" background="red" textTransform="uppercase" />

--- a/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -22,6 +22,29 @@ exports[`Box allows specifying an opacity for the background color 1`] = `
 </div>
 `;
 
+exports[`Box allows specifying an opacity for the border color 1`] = `
+.pounce-0 {
+  border: 1px solid;
+  border-color: white;
+  border-color: rgba(255,255,255,0.5);
+}
+
+<div>
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+  <div
+    class="pounce-0"
+  />
+</div>
+`;
+
 exports[`Box allows styling on demand 1`] = `
 .pounce-0 {
   color: black;

--- a/src/system/styled.ts
+++ b/src/system/styled.ts
@@ -3,7 +3,13 @@ import styled from '@emotion/styled';
 import { shouldForwardProp } from './shouldForwardProp';
 import { stylingProps, SystemProps } from './system';
 import { pseudoProps } from './pseudo';
-import { backgroundOpacityProp, sxProp, truncateProp, visuallyHiddenProp } from './utility';
+import {
+  backgroundOpacityProp,
+  borderOpacityProp,
+  sxProp,
+  truncateProp,
+  visuallyHiddenProp,
+} from './utility';
 
 export type NativeAttributes<El extends React.ElementType> = Omit<
   React.ComponentPropsWithRef<El>,
@@ -22,5 +28,6 @@ export const pounce = <T extends keyof JSX.IntrinsicElements>(tag: T) =>
   ${sxProp}
   ${truncateProp}
   ${backgroundOpacityProp}
+  ${borderOpacityProp}
   ${visuallyHiddenProp}
 ` as React.FC<PounceComponentProps<T>>;

--- a/src/system/utility.ts
+++ b/src/system/utility.ts
@@ -29,13 +29,7 @@ export const visuallyHiddenProp = ({ visuallyHidden }: any): any => {
   }
 };
 
-export const backgroundOpacityProp = ({
-  backgroundOpacity,
-  backgroundColor,
-}: {
-  backgroundOpacity: number | string;
-  backgroundColor: keyof typeof colors;
-}): any => {
+export const backgroundOpacityProp = ({ backgroundOpacity, backgroundColor }: any): any => {
   if (backgroundOpacity) {
     // As the value of `backgroundOpacity` we want to be able to parse a lot of alternatives such as: 0.5, "0.5", 50, "50"
     // Obviously the user can still add values such as "110" or "200", but we can't do much there
@@ -43,9 +37,22 @@ export const backgroundOpacityProp = ({
       typeof backgroundOpacity === 'string' ? Number(backgroundOpacity) : backgroundOpacity;
     bgOpacity = bgOpacity > 1 ? bgOpacity / 100 : bgOpacity;
 
-    const bgColor = colors[backgroundColor] ?? colors.inherit;
+    const bgColor = colors[backgroundColor as keyof typeof colors] ?? colors.inherit;
     return {
       backgroundColor: addOpacity(bgColor, bgOpacity),
+    };
+  }
+};
+
+export const borderOpacityProp = ({ borderOpacity, borderColor }: any): any => {
+  if (borderOpacity) {
+    // As the value of `borderOpacity` we want to be able to parse a lot of alternatives such as: 0.5, "0.5", 50, "50"
+    // Obviously the user can still add values such as "110" or "200", but we can't do much there
+    let opacity = typeof borderOpacity === 'string' ? Number(borderOpacity) : borderOpacity;
+    opacity = opacity > 1 ? opacity / 100 : opacity;
+
+    return {
+      borderColor: addOpacity(colors[borderColor as keyof typeof colors], opacity),
     };
   }
 };
@@ -65,4 +72,7 @@ export type UtilityProps = {
 
   /** Adds an opacity to the existing `backgroundColor` */
   backgroundOpacity?: string | number;
+
+  /** Adds an opacity to the existing `borderColor` */
+  borderOpacity?: string | number;
 };


### PR DESCRIPTION
### Background

Similar to how `backgroundOpacity` was added, this PR adds `borderOpacity` to do the same thing for border colors (rather than just background colors).

The logic is the same

### Changes

- add new `borderOpacity` prop

### Testing

- Testing steps
