### PR TITLE
[Feat] Add `closeOnOutsideClicks` on `PopoverContent` component

### DIFF
--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -30,6 +30,27 @@ A popover can have a custom trigger:
 </Popover>
 ```
 
+A popover can stay open when a click outside of it occurs:
+
+```tsx
+<Popover>
+  {({ close }) => (
+    <React.Fragment>
+      <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
+      <PopoverContent closeOnOutsideClicks={false}>
+        <Card p={6}>
+          Hello. Please click{' '}
+          <Button size="small" onClick={close}>
+            here
+          </Button>{' '}
+          to close
+        </Card>
+      </PopoverContent>
+    </React.Fragment>
+  )}
+</Popover>
+```
+
 A popover can have custom content:
 
 ```tsx

--- a/src/components/Popover/Popover.mdx
+++ b/src/components/Popover/Popover.mdx
@@ -37,7 +37,7 @@ A popover can stay open when a click outside of it occurs:
   {({ close }) => (
     <React.Fragment>
       <PopoverTrigger as={Button}>Click Me</PopoverTrigger>
-      <PopoverContent closeOnOutsideClicks={false}>
+      <PopoverContent persistOnOutsideClicks>
         <Card p={6}>
           Hello. Please click{' '}
           <Button size="small" onClick={close}>

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -106,11 +106,11 @@ describe('Popover', () => {
     expect(popup).not.toBeInTheDocument();
   });
 
-  it('closes when a click occurs anywhere outside the popup', async () => {
+  it('closes when a click occurs anywhere outside the popup if `closeOnOutsideClicks` is `true`', async () => {
     const { getByText, container } = renderWithTheme(
       <Popover>
         <PopoverTrigger as={Button}>Click me</PopoverTrigger>
-        <PopoverMenu>Boom! I am the popup</PopoverMenu>
+        <PopoverMenu closeOnOutsideClicks>Boom! I am the popup</PopoverMenu>
       </Popover>
     );
 
@@ -126,6 +126,28 @@ describe('Popover', () => {
 
     await waitForElementToBeRemoved(popup);
     expect(popup).not.toBeInTheDocument();
+  });
+
+  it('does not close when a click occurs outside the popup if `closeOnOutsideClicks` is `false`', async () => {
+    const { getByText, container } = renderWithTheme(
+      <Popover>
+        <PopoverTrigger as={Button}>Click me</PopoverTrigger>
+        <PopoverMenu closeOnOutsideClicks={false}>Boom! I am the popup</PopoverMenu>
+      </Popover>
+    );
+
+    const trigger = getByText('Click me');
+
+    fireClickAndMouseEvents(trigger);
+    const popup = getByText('Boom! I am the popup');
+
+    // wait for React to properly assign the refs. This is not an issue in real life since a user
+    // can't do it faster than React (I tried)
+    await waitMs(10);
+    fireEvent.mouseDown(container);
+    await waitMs(10);
+
+    expect(popup).toBeInTheDocument();
   });
 
   it('does NOT close when a click occurs inside the popup', async () => {

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -106,11 +106,11 @@ describe('Popover', () => {
     expect(popup).not.toBeInTheDocument();
   });
 
-  it('closes when a click occurs anywhere outside the popup if `closeOnOutsideClicks` is `true`', async () => {
+  it('closes when a click occurs anywhere outside the popup if `persistOnOutsideClicks` is `false`', async () => {
     const { getByText, container } = renderWithTheme(
       <Popover>
         <PopoverTrigger as={Button}>Click me</PopoverTrigger>
-        <PopoverMenu closeOnOutsideClicks>Boom! I am the popup</PopoverMenu>
+        <PopoverMenu persistOnOutsideClicks={false}>Boom! I am the popup</PopoverMenu>
       </Popover>
     );
 
@@ -128,11 +128,11 @@ describe('Popover', () => {
     expect(popup).not.toBeInTheDocument();
   });
 
-  it('does not close when a click occurs outside the popup if `closeOnOutsideClicks` is `false`', async () => {
+  it('does not close when a click occurs outside the popup if `persistOnOutsideClicks` is `true`', async () => {
     const { getByText, container } = renderWithTheme(
       <Popover>
         <PopoverTrigger as={Button}>Click me</PopoverTrigger>
-        <PopoverMenu closeOnOutsideClicks={false}>Boom! I am the popup</PopoverMenu>
+        <PopoverMenu persistOnOutsideClicks>Boom! I am the popup</PopoverMenu>
       </Popover>
     );
 

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -31,9 +31,9 @@ export interface PopoverContentProps {
     | 'right-top';
 
   /**
-   * Whether the popover should hide when a click outside it occurs
+   * Whether the popover should remain open when a click outside it occurs
    */
-  closeOnOutsideClicks?: boolean;
+  persistOnOutsideClicks?: boolean;
 
   /**
    * @ignore
@@ -43,7 +43,7 @@ export interface PopoverContentProps {
 
 const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
   function PopoverContent(
-    { alignment = 'bottom-left', children, closeOnOutsideClicks = true, ...rest },
+    { alignment = 'bottom-left', children, persistOnOutsideClicks = false, ...rest },
     forwardedRef
   ) {
     const popoverAlignment = usePopoverContentAlignment(alignment);
@@ -62,7 +62,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     useOutsideClick({
       refs: [popoverRef, triggerRef],
       callback: () => isOpen && close(),
-      disabled: !closeOnOutsideClicks || !isOpen,
+      disabled: persistOnOutsideClicks || !isOpen,
     });
 
     // Close on ESC key presses

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -31,13 +31,21 @@ export interface PopoverContentProps {
     | 'right-top';
 
   /**
+   * Whether the popover should hide when a click outside it occurs
+   */
+  closeOnOutsideClicks?: boolean;
+
+  /**
    * @ignore
    */
   children: ReactNode;
 }
 
 const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
-  function PopoverContent({ alignment = 'bottom-left', children, ...rest }, forwardedRef) {
+  function PopoverContent(
+    { alignment = 'bottom-left', children, closeOnOutsideClicks = true, ...rest },
+    forwardedRef
+  ) {
     const popoverAlignment = usePopoverContentAlignment(alignment);
     const { popoverId, isOpen, triggerRef, popoverRef, close } = usePopoverContext();
 
@@ -54,7 +62,7 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
     useOutsideClick({
       refs: [popoverRef, triggerRef],
       callback: () => isOpen && close(),
-      disabled: !isOpen,
+      disabled: !closeOnOutsideClicks || !isOpen,
     });
 
     // Close on ESC key presses


### PR DESCRIPTION
### Background

The popover closes (by default) whenever a click outside it occurs. There are cases though, where you don't want it to close when clicks outside it occur, so we should add this capability to the component

#### Showcase


https://user-images.githubusercontent.com/10436045/189114572-95aad452-5517-4177-bc13-4d42fcf3b638.mov



### Changes

- Add new `closeOnOutsideClicks` property on `PopoverContent`
- Update & write new tests for this use case
- Update docs to add a new example

### Testing

- Unit tests
