### PR TITLE
feat: enhance Badge to allow solid background

### DIFF
--- a/src/components/Badge/Badge.mdx
+++ b/src/components/Badge/Badge.mdx
@@ -10,6 +10,19 @@ A badge can have different colors:
 </Flex>
 ```
 
+A badge can have a solid background:
+
+```typescript jsx
+<Flex align="center" spacing={2}>
+  <Badge color="blue-400" hasSolidBackground>
+    Solid Blue
+  </Badge>
+  <Badge color="red-300" hasSolidBackground>
+    Solid Red
+  </Badge>
+</Flex>
+```
+
 A badge can have different sizes:
 
 ```typescript jsx

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -43,3 +43,13 @@ it('renders `medium` size correctly', () => {
 
   expect(container).toMatchSnapshot();
 });
+
+it('renders a `solid` background correctly', () => {
+  const { container } = renderWithTheme(
+    <Badge color="blue-400" hasSolidBackground>
+      Solid
+    </Badge>
+  );
+
+  expect(container).toMatchSnapshot();
+});

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -8,6 +8,9 @@ export interface BadgeProps {
   /** The color theme of the badge */
   color: keyof Theme['colors'];
 
+  /** The badge has a solid background */
+  hasSolidBackground?: boolean;
+
   /** Whether the badge should stretch to fill his parent or not */
   stretch?: boolean;
 
@@ -22,7 +25,15 @@ export interface BadgeProps {
 
 /** A badge is simply a visual label to accompany & characterize a certain text*/
 const Badge = React.forwardRef<HTMLElement, BadgeProps>(function Badge(
-  { color, children, stretch = false, size = 'medium', emphasized = false, ...rest },
+  {
+    color,
+    children,
+    stretch = false,
+    size = 'medium',
+    emphasized = false,
+    hasSolidBackground,
+    ...rest
+  },
   ref
 ) {
   const theme = useTheme();
@@ -42,7 +53,7 @@ const Badge = React.forwardRef<HTMLElement, BadgeProps>(function Badge(
       border="1px solid"
       borderRadius="small"
       borderColor={color}
-      backgroundColor={addOpacity(theme.colors[color], 0.3)}
+      backgroundColor={hasSolidBackground ? color : addOpacity(theme.colors[color], 0.3)}
       alignItems="center"
       justifyContent="center"
       fontSize={hasMediumSize ? 'small' : 'x-small'}

--- a/src/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -204,3 +204,46 @@ exports[`renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders a \`solid\` background correctly 1`] = `
+.pounce-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: default;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  text-align: center;
+  font-weight: 400;
+  text-transform: none;
+  border: 1px solid;
+  border-radius: 2px;
+  border-color: #0081C5;
+  background-color: #0081C5;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+<div>
+  <div
+    aria-atomic="true"
+    class="pounce-0"
+    role="status"
+  >
+    Solid
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Background

The work for the Trial Governors requires enhancing the `Badge` component with the option of a solid background

<img width="751" alt="Screen Shot 2022-09-20 at 5 22 54 PM" src="https://user-images.githubusercontent.com/4212239/191381892-0794a33f-a218-4590-a71b-174ad7f79554.png">

### Changes

- `hadSolidBackground` prop has been added to the `Badge` component

### Pounce Docs Screenshot
<img width="970" alt="Screen Shot 2022-09-20 at 5 24 27 PM" src="https://user-images.githubusercontent.com/4212239/191381997-b8d4ebe2-de4c-4252-ae40-f27ef5d29853.png">
