### PR TITLE
[refactor] JG - adding disableAnimation prop to Alert

### DIFF
--- a/src/components/Alert/Alert.mdx
+++ b/src/components/Alert/Alert.mdx
@@ -210,3 +210,25 @@ Alerts can have actions associated with them:
   </Flex>
 </Box>
 ```
+
+Alerts can opt out of the animation functionality:
+
+```typescript jsx
+<Box width={1}>
+  <Box mb={3}>
+    <Alert disableAnimation variant="success" title="This is a success alert" />
+  </Box>
+  <Box mb={3}>
+    <Alert disableAnimation variant="info" title="This is an info alert" />
+  </Box>
+  <Box mb={3}>
+    <Alert disableAnimation variant="warning" title="This is a warning alert" />
+  </Box>
+  <Box mb={3}>
+    <Alert disableAnimation variant="error" title="This is an error alert" discardable />
+  </Box>
+  <Box>
+    <Alert disableAnimation variant="default" title="This is the default alert" discardable />
+  </Box>
+</Box>
+```

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { renderWithTheme } from '../../../jest/utils';
+import Alert from '../Alert';
+
+describe('Alert', () => {
+  it('renders without a collapsible container when disableAnimation is passed', () => {
+    const { container } = renderWithTheme(
+      <Alert disableAnimation variant="success" title="This is a success alert" />
+    );
+
+    // We expect the first child to be the alert itself
+    expect(container.firstChild).toHaveAttribute('role', 'dialog');
+  });
+  it('renders with a collapsible container when disableAnimation is not passed', () => {
+    const { container } = renderWithTheme(
+      <Alert variant="success" title="This is a success alert" />
+    );
+
+    // We expect the first child to be the collapse related wrapper
+    expect(container.firstChild).not.toHaveAttribute('role', 'dialog');
+  });
+});

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import ControlledAlert, { ControlledAlertProps } from '../utils/ControlledAlert';
 import Collapse from '../Collapse';
+import omit from 'lodash/omit';
 
-export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & { onClose?: () => void };
+export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & {
+  onClose?: () => void;
+  disableAnimation?: boolean;
+};
+
+const noop = () => {};
 
 /** An Alert component is simply a container for text that should capture the user's attention */
-const Alert: React.FC<AlertProps> = ({ onClose, ...rest }) => {
+const Alert: React.FC<AlertProps> = ({ onClose, disableAnimation = false, ...rest }) => {
   const [open, setOpen] = React.useState(true);
+  // Remove the discardable prop when the disableAnimation prop is true
+  const props = disableAnimation ? omit(rest, 'discardable') : rest;
 
   const handleClose = React.useCallback(() => {
     setOpen(false);
@@ -16,9 +24,11 @@ const Alert: React.FC<AlertProps> = ({ onClose, ...rest }) => {
     }
   }, [setOpen, onClose]);
 
-  return (
+  return disableAnimation ? (
+    <ControlledAlert {...props} open onClose={noop} />
+  ) : (
     <Collapse open={open}>
-      <ControlledAlert {...rest} open onClose={handleClose} />
+      <ControlledAlert {...props} open onClose={handleClose} />
     </Collapse>
   );
 };

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -21,9 +21,11 @@ const Alert: React.FC<AlertProps> = ({ onClose, disableAnimation = false, ...res
     }
   }, [setOpen, onClose]);
 
-  return disableAnimation ? (
-    <ControlledAlert {...rest} open={open} onClose={handleClose} />
-  ) : (
+  if (disableAnimation) {
+    return <ControlledAlert {...rest} open={open} onClose={handleClose} />;
+  }
+
+  return (
     <Collapse open={open}>
       <ControlledAlert {...rest} open onClose={handleClose} />
     </Collapse>

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import ControlledAlert, { ControlledAlertProps } from '../utils/ControlledAlert';
 import Collapse from '../Collapse';
+import omit from 'lodash/omit';
+import { noop } from '../../utils/helpers';
 
-export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & { onClose?: () => void };
+export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & {
+  onClose?: () => void;
+  disableAnimation?: boolean;
+};
 
 /** An Alert component is simply a container for text that should capture the user's attention */
-const Alert: React.FC<AlertProps> = ({ onClose, ...rest }) => {
+const Alert: React.FC<AlertProps> = ({ onClose, disableAnimation = false, ...rest }) => {
   const [open, setOpen] = React.useState(true);
+  // Remove the discardable prop when the disableAnimation prop is true
+  const props = disableAnimation ? omit(rest, 'discardable') : rest;
 
   const handleClose = React.useCallback(() => {
     setOpen(false);
@@ -16,9 +23,11 @@ const Alert: React.FC<AlertProps> = ({ onClose, ...rest }) => {
     }
   }, [setOpen, onClose]);
 
-  return (
+  return disableAnimation ? (
+    <ControlledAlert {...props} open onClose={noop} />
+  ) : (
     <Collapse open={open}>
-      <ControlledAlert {...rest} open onClose={handleClose} />
+      <ControlledAlert {...props} open onClose={handleClose} />
     </Collapse>
   );
 };

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import ControlledAlert, { ControlledAlertProps } from '../utils/ControlledAlert';
 import Collapse from '../Collapse';
-import omit from 'lodash/omit';
-import { noop } from '../../utils/helpers';
 
 export type AlertProps = Omit<ControlledAlertProps, 'open' | 'onClose'> & {
   onClose?: () => void;
+
+  /** Whether the Alert is wrapped in a Collapse animation wrapper */
   disableAnimation?: boolean;
 };
 
 /** An Alert component is simply a container for text that should capture the user's attention */
 const Alert: React.FC<AlertProps> = ({ onClose, disableAnimation = false, ...rest }) => {
   const [open, setOpen] = React.useState(true);
-  // Remove the discardable prop when the disableAnimation prop is true
-  const props = disableAnimation ? omit(rest, 'discardable') : rest;
 
   const handleClose = React.useCallback(() => {
     setOpen(false);
@@ -24,10 +22,10 @@ const Alert: React.FC<AlertProps> = ({ onClose, disableAnimation = false, ...res
   }, [setOpen, onClose]);
 
   return disableAnimation ? (
-    <ControlledAlert {...props} open onClose={noop} />
+    <ControlledAlert {...rest} open={open} onClose={handleClose} />
   ) : (
     <Collapse open={open}>
-      <ControlledAlert {...props} open onClose={handleClose} />
+      <ControlledAlert {...rest} open onClose={handleClose} />
     </Collapse>
   );
 };


### PR DESCRIPTION
### Background

This adds the option to opt out of the Alert animation. A new `disableAnimation` prop can be passed in that will prevent the `Alert` from being wrapped with a `Collapse` component.

### Testing

- Tested on the documents page to ensure the animate-in functionality was not present when the `disableAnimation` was passed in.
