### PR TITLE
fix: update Modal to allow passing of onDismiss prop

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -26,6 +26,14 @@ export interface ModalProps {
 
   /** The id of the HTML node that contains the text of the modal */
   'aria-describedby'?: string;
+
+  /** Callback fired when user hits "Escape" or clicks outside the dialog.
+   *
+   * When _strictly necessary_, this can be used to prevent a user from closing
+   * the dialog, but otherwise it is important to allow users to close dialogs
+   * for accessibility reasons.
+   */
+  onDismiss?: (event?: React.SyntheticEvent) => void;
 }
 
 /**
@@ -37,6 +45,7 @@ const Modal: React.FC<ModalProps> = ({
   children,
   open,
   onClose,
+  onDismiss,
   showCloseButton,
   ...rest
 }) => {
@@ -55,7 +64,7 @@ const Modal: React.FC<ModalProps> = ({
             <AnimatedDialogOverlay
               key={key}
               isOpen={item}
-              onDismiss={onClose}
+              onDismiss={onDismiss ? onDismiss : onClose}
               style={{ overflow: 'visible', opacity: styles.opacity }}
               as={'div'}
             >


### PR DESCRIPTION
### Background

Related to [https://app.asana.com/0/1201267919523621/1200485078649931/f](https://app.asana.com/0/1201267919523621/1200485078649931/f)

The `ProductConsentModal`, served when a user first logs in to Panther, may be closed by hitting "escape" or clicking outside the modal. While this is typically desired behavior for modals for accessibility reasons, in this instance, we've allowed a loophole for users to use Panther without _explicitly_ agreeing to the legal terms. In advance of our trial/Odin launch, we need to close this loophole as we will have less oversight of these users.

### Changes

- Extends the Pounce Modal to allow the `onDismiss` prop to be passed.

This is part 1 of 2 for this story. There is additional work to be done in `panther-enterprise`.

Docs for this prop: https://reach.tech/dialog/#dialog-ondismiss

### Testing

- Testing steps
