### PR TITLE
feat: allow breadcrumbs to be truncated when more than 3 items exist

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -11,10 +11,39 @@ const items = [
     href: '/#/Flex',
   },
   {
-    children: <MyCustomTitle />,
-    href: '/#/MyCustomTitle',
+    children: 'Third page',
+    href: '/#/Cell',
   },
 ];
 
 <Breadcrumbs items={items} />;
+```
+
+Breadcrumbs can be truncated when more than 3 items exist:
+
+```typescript jsx
+const items = [
+  {
+    children: 'First page',
+    href: '/#/Box',
+  },
+  {
+    children: 'Second page',
+    href: '/#/Flex',
+  },
+  {
+    children: 'Third page',
+    href: '/#/Modal',
+  },
+  {
+    children: 'Fourth page',
+    href: '/#/Checkbox',
+  },
+  {
+    children: 'Fifth page',
+    href: '/#/Cell',
+  },
+];
+
+<Breadcrumbs items={items} truncate />;
 ```

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import Breadcrumbs from './index';
+import { renderWithTheme } from '../../../jest/utils';
+
+const mockCrumbs = [
+  {
+    children: 'First page',
+    href: '/',
+  },
+  {
+    children: 'Second page',
+    href: '/secondpage',
+  },
+  {
+    children: 'Third page',
+    href: '/thirdpage',
+  },
+  {
+    children: 'Fourth page',
+    href: '/fourthpage',
+  },
+  {
+    children: 'Fifth page',
+    href: '/fifthpage',
+  },
+  {
+    children: 'Sixth page',
+    href: '/sixthpage',
+  },
+  {
+    children: 'Seventh page',
+    href: '/seventhpage',
+  },
+];
+const truncatedCrumbs = mockCrumbs.slice(1, -2);
+const visibleCrumbs = mockCrumbs.filter(index => {
+  return truncatedCrumbs.indexOf(index) === -1;
+});
+
+describe('Breadcrumbs', () => {
+  it('renders all items without truncation', () => {
+    const { queryAllByRole, queryByLabelText, queryByText } = renderWithTheme(
+      <Breadcrumbs items={mockCrumbs} />
+    );
+
+    // verify expected breadcrumbs and chevrons exist
+    mockCrumbs.forEach(crumb => {
+      expect(queryByText(crumb.children)).toBeTruthy();
+    });
+    expect(queryAllByRole('presentation')).toHaveLength(mockCrumbs.length - 1);
+
+    // verify truncated menu does not exist
+    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeNull();
+  });
+
+  it('renders breadcrumbs with truncation', () => {
+    const { queryAllByRole, queryByLabelText, queryByText } = renderWithTheme(
+      <Breadcrumbs items={mockCrumbs} truncate />
+    );
+
+    visibleCrumbs.forEach(crumb => {
+      expect(queryByText(crumb.children)).toBeTruthy();
+    });
+    truncatedCrumbs.forEach(crumb => {
+      expect(queryByText(crumb.children)).toBeNull();
+    });
+    expect(queryAllByRole('presentation')).toHaveLength(3);
+    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeTruthy();
+  });
+
+  it('renders breadcrumbs without truncation when list length is less than 4', () => {
+    const { queryAllByRole, queryByLabelText, queryByText } = renderWithTheme(
+      <Breadcrumbs items={visibleCrumbs} truncate />
+    );
+
+    // verify expected breadcrumbs and chevrons exist
+    visibleCrumbs.forEach(crumb => {
+      expect(queryByText(crumb.children)).toBeTruthy();
+    });
+    expect(queryAllByRole('presentation')).toHaveLength(visibleCrumbs.length - 1);
+
+    // verify truncated menu does not exist
+    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeNull();
+  });
+});

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -50,7 +50,7 @@ describe('Breadcrumbs', () => {
     expect(queryAllByRole('presentation')).toHaveLength(mockCrumbs.length - 1);
 
     // verify truncated menu does not exist
-    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeNull();
+    expect(queryByLabelText('Toggle additional breadcrumbs')).toBeNull();
   });
 
   it('renders breadcrumbs with truncation', () => {
@@ -65,7 +65,7 @@ describe('Breadcrumbs', () => {
       expect(queryByText(crumb.children)).toBeNull();
     });
     expect(queryAllByRole('presentation')).toHaveLength(3);
-    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeTruthy();
+    expect(queryByLabelText('Toggle additional breadcrumbs')).toBeTruthy();
   });
 
   it('renders breadcrumbs without truncation when list length is less than 4', () => {
@@ -80,6 +80,6 @@ describe('Breadcrumbs', () => {
     expect(queryAllByRole('presentation')).toHaveLength(visibleCrumbs.length - 1);
 
     // verify truncated menu does not exist
-    expect(queryByLabelText('Truncated breadcrumb list toggle')).toBeNull();
+    expect(queryByLabelText('Toggle additional breadcrumbs')).toBeNull();
   });
 });

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -38,7 +38,7 @@ const visibleCrumbs = mockCrumbs.filter(index => {
 });
 
 describe('Breadcrumbs', () => {
-  it('renders all items without truncation', () => {
+  it('renders breadcrumbs without truncation', () => {
     const { queryAllByRole, queryByLabelText, queryByText } = renderWithTheme(
       <Breadcrumbs items={mockCrumbs} />
     );

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Breadcrumbs from './index';
-import { renderWithTheme } from '../../../jest/utils';
+import { fireEvent, renderWithTheme, waitFor } from '../../../jest/utils';
 
 const mockCrumbs = [
   {
@@ -54,10 +54,11 @@ describe('Breadcrumbs', () => {
   });
 
   it('renders breadcrumbs with truncation', () => {
-    const { queryAllByRole, queryByLabelText, queryByText } = renderWithTheme(
+    const { queryAllByRole, getByLabelText, queryByText } = renderWithTheme(
       <Breadcrumbs items={mockCrumbs} truncate />
     );
 
+    // verify inital visible state
     visibleCrumbs.forEach(crumb => {
       expect(queryByText(crumb.children)).toBeTruthy();
     });
@@ -65,7 +66,12 @@ describe('Breadcrumbs', () => {
       expect(queryByText(crumb.children)).toBeNull();
     });
     expect(queryAllByRole('presentation')).toHaveLength(3);
-    expect(queryByLabelText('Toggle additional breadcrumbs')).toBeTruthy();
+
+    // toggle truncated menu
+    fireEvent.click(getByLabelText('Toggle additional breadcrumbs'));
+    truncatedCrumbs.forEach(async crumb => {
+      await waitFor(() => expect(queryByText(crumb.children)).toBeTruthy());
+    });
   });
 
   it('renders breadcrumbs without truncation when list length is less than 4', () => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import Box from '../Box';
+import Button from '../Button';
+import Card from '../Card';
 import Flex from '../Flex';
 import Icon from '../Icon';
-import Box from '../Box';
 import Link, { LinkProps } from '../Link';
+import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 
 export interface BreadcrumbItem {
   /** The URL that this Breadcrumbs should navigate to when clicked */
@@ -16,48 +19,135 @@ export interface BreadcrumbItem {
 export interface BreadcrumbProps extends Pick<LinkProps, 'as'> {
   /** A list of `BreadcrumbsItem` objects ( `{href,children}` ) that will construct the Breadcrumb */
   items: BreadcrumbItem[];
+  /** Truncates component if breadcrumb list is too long.
+   * At least 4 breadcrumbs must exist for truncation to occur.
+   */
+  truncate?: boolean;
 }
 
+interface IBreadcrumbLink {
+  crumb: BreadcrumbItem;
+  isLastBreadcrumb?: boolean;
+  showChevron?: boolean;
+}
+
+type ITruncatedBreadcrumbs = Omit<BreadcrumbProps, 'truncate'>;
+
+const BreadcrumbChevron: React.ElementType = () => {
+  return <Icon type="chevron-right" mx={2} color="blue-300" size="medium" role="presentation" />;
+};
+
+const BreadcrumbLink: React.ElementType = ({
+  crumb,
+  isLastBreadcrumb = false,
+  showChevron = true,
+  ...rest
+}: IBreadcrumbLink) => {
+  return (
+    <Flex
+      key={crumb.href}
+      as="li"
+      alignItems="center"
+      fontSize="medium"
+      fontWeight={isLastBreadcrumb ? 'bold' : 'normal'}
+      aria-current={isLastBreadcrumb ? 'page' : undefined}
+    >
+      <Link
+        to={crumb.href}
+        variant="neutral"
+        border="none"
+        truncated
+        maxWidth="450px"
+        data-active={isLastBreadcrumb ? true : undefined}
+        {...rest}
+      >
+        {crumb.children}
+      </Link>
+      {!isLastBreadcrumb && showChevron && <BreadcrumbChevron />}
+    </Flex>
+  );
+};
+
+const TruncatedBreadcrumbs: React.ElementType = ({ items, ...rest }: ITruncatedBreadcrumbs) => {
+  const firstItem = items[0];
+  const truncatedList = items.slice(1, -2);
+  const remainingCrumbs = items.slice(-2);
+
+  return (
+    <React.Fragment>
+      {/* first crumb */}
+      <BreadcrumbLink crumb={firstItem} {...rest} />
+
+      {/* truncated crumbs */}
+      <Popover>
+        {() => (
+          <Flex alignItems="center">
+            <PopoverTrigger
+              as={Button}
+              id="truncated-breadcrumb-list"
+              variantColor="transparent"
+              padding={0}
+              height="auto"
+              aria-label="Truncated breadcrumb list toggle"
+            >
+              ...
+            </PopoverTrigger>
+            <PopoverContent alignment="bottom-right">
+              <Card as="ul" my={1} px={5} pt={5} shadow="dark300" minWidth={180}>
+                {truncatedList.map(item => {
+                  return (
+                    <Card key={item.href} minWidth={180} pb={5}>
+                      <BreadcrumbLink crumb={item} showChevron={false} {...rest} />
+                    </Card>
+                  );
+                })}
+              </Card>
+            </PopoverContent>
+            <BreadcrumbChevron />
+          </Flex>
+        )}
+      </Popover>
+
+      {/* remaining crumbs */}
+      {remainingCrumbs.map((item, index) => {
+        const isLastBreadcrumb = index === 1;
+        return (
+          <BreadcrumbLink
+            key={item.href}
+            crumb={item}
+            isLastBreadcrumb={isLastBreadcrumb}
+            {...rest}
+          />
+        );
+      })}
+    </React.Fragment>
+  );
+};
+
 /** Breadcrumb is a way to navigate back to where you came from within the app */
-const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, ...rest }) => {
+const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, truncate = false, ...rest }) => {
+  const truncateBreadcrumbs = truncate && items.length > 3;
+
   return (
     <Box as="nav" aria-label="Breadcrumbs">
       <Flex as="ol">
-        {items.map((item, index) => {
-          const isLastBreadcrumb = index === items.length - 1;
-
-          return (
-            <Flex
-              key={item.href}
-              as="li"
-              alignItems="center"
-              fontSize="medium"
-              fontWeight={isLastBreadcrumb ? 'bold' : 'normal'}
-              aria-current={isLastBreadcrumb ? 'page' : undefined}
-            >
-              <Link
-                to={item.href}
-                variant="neutral"
-                border="none"
-                truncated
-                maxWidth="450px"
-                data-active={isLastBreadcrumb ? true : undefined}
-                {...rest}
-              >
-                {item.children}
-              </Link>
-              {!isLastBreadcrumb && (
-                <Icon
-                  type="chevron-right"
-                  mx={2}
-                  color="blue-300"
-                  size="medium"
-                  role="presentation"
+        {truncateBreadcrumbs ? (
+          <TruncatedBreadcrumbs items={items} {...rest} />
+        ) : (
+          <React.Fragment>
+            {items.map((item, index) => {
+              const isLastBreadcrumb = index === items.length - 1;
+              return (
+                <BreadcrumbLink
+                  key={item.href}
+                  crumb={item}
+                  isLastBreadcrumb={isLastBreadcrumb}
+                  {...rest}
                 />
-              )}
-            </Flex>
-          );
-        })}
+              );
+            })}
+          </React.Fragment>
+        )}
       </Flex>
     </Box>
   );

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import AbstractButton from '../AbstractButton';
 import Box from '../Box';
-import Button from '../Button';
 import Card from '../Card';
 import Flex from '../Flex';
 import Icon from '../Icon';
@@ -81,14 +81,13 @@ const TruncatedBreadcrumbs: React.ElementType = ({ items, ...rest }: ITruncatedB
       {/* truncated crumbs */}
       <Popover>
         {() => (
-          <Flex alignItems="center">
+          <Flex as="li" alignItems="center">
             <PopoverTrigger
-              as={Button}
-              id="truncated-breadcrumb-list"
+              as={AbstractButton}
               variantColor="transparent"
               padding={0}
               height="auto"
-              aria-label="Truncated breadcrumb list toggle"
+              aria-label="Toggle additional breadcrumbs"
             >
               ...
             </PopoverTrigger>
@@ -96,9 +95,14 @@ const TruncatedBreadcrumbs: React.ElementType = ({ items, ...rest }: ITruncatedB
               <Card as="ul" my={1} px={5} pt={5} shadow="dark300" minWidth={180}>
                 {truncatedList.map(item => {
                   return (
-                    <Card key={item.href} minWidth={180} pb={5}>
-                      <BreadcrumbLink crumb={item} showChevron={false} {...rest} />
-                    </Card>
+                    <BreadcrumbLink
+                      key={item.href}
+                      pb={5}
+                      width="100%"
+                      crumb={item}
+                      showChevron={false}
+                      {...rest}
+                    />
                   );
                 })}
               </Card>
@@ -130,7 +134,7 @@ const Breadcrumbs: React.FC<BreadcrumbProps> = ({ items, truncate = false, ...re
 
   return (
     <Box as="nav" aria-label="Breadcrumbs">
-      <Flex as="ol">
+      <Flex as="ul">
         {truncateBreadcrumbs ? (
           <TruncatedBreadcrumbs items={items} {...rest} />
         ) : (


### PR DESCRIPTION
### Background

Relates to the [Add Breadcrumb to Top Navigation Bar](https://app.asana.com/0/1202391056484782/1203253677340404/f) story.

In order to move the breadcrumbs to the Top Navigation, we need to plan for the possibility that the length of the breadcrumb component will exceed the space available. [Design has advised we update the breadcrumbs to be truncated when this occurs.](https://www.figma.com/file/A0FIgEQziIb0WZAd8Tf7Tj/04-Detections-%E2%9C%85?node-id=3027%3A134832&t=BhKCXFSaThGWm2r2-1)

### Changes

- Describe changes here

### Testing
<img width="654" alt="Screen Shot 2022-11-16 at 7 21 49 PM" src="https://user-images.githubusercontent.com/4212239/202348357-f28f612c-75ec-448c-9111-5ed1bfad2435.png">

### Screenshots
<img width="959" alt="Screen Shot 2022-11-16 at 7 31 08 PM" src="https://user-images.githubusercontent.com/4212239/202348385-8591cb5c-92a2-457b-9b88-401156754656.png">

