### PR TITLE
test: fixing IconButton tests

### DIFF
--- a/src/components/IconButton/IconButton.mdx
+++ b/src/components/IconButton/IconButton.mdx
@@ -116,26 +116,21 @@ An IconButton can have a colored icon:
 
 ```typescript jsx
 <SimpleGrid columns={4} gap={4}>
-  <IconButton
-    icon="user"
-    variantColor="navyblue-300"
-    variantIconColor="teal-500"
-    aria-label="User"
-  />
+  <IconButton icon="user" variantColor="navyblue-300" iconColor="teal-500" aria-label="User" />
   <IconButton
     variant="ghost"
     icon="user"
     variantColor="navyblue-300"
-    variantIconColor="teal-500"
+    iconColor="teal-500"
     aria-label="User"
   />
   <IconButton
     variant="outline"
     icon="user"
     variantColor="navyblue-300"
-    variantIconColor="teal-500"
+    iconColor="teal-500"
     aria-label="User"
   />
-  <IconButton variant="unstyled" icon="user" aria-label="User" variantIconColor="teal-500" />
+  <IconButton variant="unstyled" icon="user" aria-label="User" iconColor="teal-500" />
 </SimpleGrid>
 ```


### PR DESCRIPTION
### Background

I changed the name from variantIconColor to iconColor a while ago, but forgot to change the tests, so they weren't working

### Changes

Before:
![image](https://user-images.githubusercontent.com/10763539/203665421-dc5b2967-6442-43b6-88e3-3ecb2e2b67f7.png)

After:
![image](https://user-images.githubusercontent.com/10763539/203665394-d1620a79-9184-436a-afff-3ab8bf6833d5.png)


### Testing

Check to see that the "An IconButton can have a colored icon" test has colors
