### PR TITLE
feat: enhance tooltip to accept a custom wrapper

### DIFF
--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -30,6 +30,44 @@ Content can be anything as well:
 </Tooltip>
 ```
 
+Content can have a wrapper:
+
+```typescript jsx
+// Create a custom wrapper
+const TooltipWrapper: React.FC = ({ children }) => {
+  return (
+    <Box
+      position="relative"
+      borderRadius="medium"
+      bg="black"
+      p={2}
+      m={2}
+      fontSize="small"
+      boxShadow="dark250"
+      _before={{
+        content: '""',
+        position: 'absolute',
+        right: '100%',
+        top: '50%',
+        borderWidth: '6px',
+        borderStyle: 'solid',
+        borderTopColor: 'transparent',
+        borderRightColor: 'black',
+        borderBottomColor: 'transparent',
+        borderLeftColor: 'transparent',
+        transform: 'translateY(-50%)',
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+<Tooltip content="Lorem ipsum dolor sit amet, consectetur" contentWrapper={TooltipWrapper}>
+  <Box>Hover me to see the new wrapper</Box>
+</Tooltip>;
+```
+
 The default right-side positioning can be customized:
 
 ```typescript jsx

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -63,7 +63,7 @@ const TooltipWrapper: React.FC = ({ children }) => {
   );
 };
 
-<Tooltip content="Lorem ipsum dolor sit amet, consectetur" contentWrapper={TooltipWrapper}>
+<Tooltip content="Lorem ipsum dolor sit amet, consectetur" wrapper={TooltipWrapper}>
   <Box>Hover me to see the new wrapper</Box>
 </Tooltip>;
 ```

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireClickAndMouseEvents, fireEvent, renderWithTheme } from 'test-utils';
+import Tooltip from './Tooltip';
+import Box from '../Box';
+import IconButton from '../IconButton';
+
+const TooltipWrapper: React.FC = ({ children }) => {
+  return (
+    <Box
+      position="relative"
+      borderRadius="medium"
+      bg="black"
+      p={2}
+      m={2}
+      fontSize="small"
+      boxShadow="dark250"
+      _before={{
+        content: '""',
+        position: 'absolute',
+        right: '100%',
+        top: '50%',
+        borderWidth: '6px',
+        borderStyle: 'solid',
+        borderTopColor: 'transparent',
+        borderRightColor: 'black',
+        borderBottomColor: 'transparent',
+        borderLeftColor: 'transparent',
+        transform: 'translateY(-50%)',
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+describe('Tooltip', () => {
+  it('matches snapshot for tooltip', () => {
+    const { container } = renderWithTheme(
+      <Tooltip content="Lorem ipsum dolor sit amet, consectetur">
+        <Box>Hover me to see the tooltip</Box>
+      </Tooltip>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('show the tooltip when we hover', async () => {
+    const { getByText, findByText } = renderWithTheme(
+      <Tooltip content="Boom! I am the tooltip">
+        <Box>Hover me to see the tooltip</Box>
+      </Tooltip>
+    );
+
+    const textToHover = getByText('Hover me to see the tooltip');
+    expect(textToHover).toBeInTheDocument();
+    fireClickAndMouseEvents(textToHover);
+    fireEvent.mouseOver(textToHover);
+    expect(await findByText('Boom! I am the tooltip')).toBeInTheDocument();
+  });
+
+  it('show the tooltip for an Icon', async () => {
+    const { getByLabelText, findByText } = renderWithTheme(
+      <Tooltip content="Boom! I am the user!">
+        <IconButton icon="user" aria-label="See user" />
+      </Tooltip>
+    );
+
+    const textToHover = getByLabelText('See user');
+    expect(textToHover).toBeInTheDocument();
+    fireClickAndMouseEvents(textToHover);
+    fireEvent.mouseOver(textToHover);
+    expect(await findByText('Boom! I am the user!')).toBeInTheDocument();
+  });
+
+  it('show the tooltip with a custom content', async () => {
+    const { getByText, findByText } = renderWithTheme(
+      <Tooltip content="Lorem ipsum dolor sit amet, consectetur" wrapper={TooltipWrapper}>
+        <Box>Hover me to see the new wrapper</Box>
+      </Tooltip>
+    );
+
+    const textToHover = getByText('Hover me to see the new wrapper');
+    expect(textToHover).toBeInTheDocument();
+    fireClickAndMouseEvents(textToHover);
+    fireEvent.mouseOver(textToHover);
+    const tooltip = await findByText('Lorem ipsum dolor sit amet, consectetur');
+    expect(tooltip).toHaveStyle('background-color: rgb(0, 0, 0)');
+  });
+});

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,9 +7,20 @@ import Box from '../Box';
 
 const AnimatedTooltipPopup = animated(TooltipPopup);
 
+const DefaultWrapper: React.FC = ({ children }) => {
+  return (
+    <Box borderRadius="medium" bg="navyblue-300" p={4} m={2} fontSize="small" boxShadow="dark250">
+      {children}
+    </Box>
+  );
+};
+
 export interface TooltipProps {
-  /** The string or HTML that the tooltip will show*/
+  /** The string or HTML that the tooltip will show */
   content: string | React.ReactElement;
+
+  /** The wrapper that contains the contnet */
+  contentWrapper?: React.ElementType;
 
   /** The position of the tooltip relative to the content */
   position?: Position;
@@ -17,10 +28,9 @@ export interface TooltipProps {
   /** @ignore */
   children: React.ReactElement;
 }
-
 /** A tooltip is a helper that shows some helping text when hovering or clicking something */
 const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
-  { content, position = positionRight, children },
+  { content, position = positionRight, contentWrapper = DefaultWrapper, children },
   ref
 ) {
   const [trigger, { triggerRect }, isVisible] = useTooltip();
@@ -36,6 +46,8 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
     trigger,
   ]);
 
+  const ContentWrapper = contentWrapper;
+
   return (
     <React.Fragment>
       {childrenWithHandler}
@@ -50,18 +62,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
               ref={ref}
               position={position}
               as={'div'}
-              label={
-                <Box
-                  borderRadius="medium"
-                  bg="navyblue-300"
-                  p={4}
-                  m={2}
-                  fontSize="small"
-                  boxShadow="dark250"
-                >
-                  {content}
-                </Box>
-              }
+              label={<ContentWrapper>{content}</ContentWrapper>}
             />
           )
       )}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ export interface TooltipProps {
   content: string | React.ReactElement;
 
   /** The wrapper that contains the contnet */
-  contentWrapper?: React.ElementType;
+  wrapper?: React.ElementType;
 
   /** The position of the tooltip relative to the content */
   position?: Position;
@@ -30,7 +30,7 @@ export interface TooltipProps {
 }
 /** A tooltip is a helper that shows some helping text when hovering or clicking something */
 const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
-  { content, position = positionRight, contentWrapper = DefaultWrapper, children },
+  { content, position = positionRight, wrapper = DefaultWrapper, children },
   ref
 ) {
   const [trigger, { triggerRect }, isVisible] = useTooltip();
@@ -46,7 +46,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
     trigger,
   ]);
 
-  const ContentWrapper = contentWrapper;
+  const Wrapper = wrapper;
 
   return (
     <React.Fragment>
@@ -62,7 +62,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(function Tooltip(
               ref={ref}
               position={position}
               as={'div'}
-              label={<ContentWrapper>{content}</ContentWrapper>}
+              label={<Wrapper>{content}</Wrapper>}
             />
           )
       )}

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip matches snapshot for tooltip 1`] = `
+<div>
+  <div
+    class="pounce-0"
+    data-reach-tooltip-trigger=""
+    data-state="tooltip-hidden"
+  >
+    Hover me to see the tooltip
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Background

The tooltip component is a bit limited, so I introduced the content wrapper that will enhance the tooltip capability to modify the content container, e.g. background colour or adding an arrow!
![Screenshot 2022-12-02 at 2 38 34 PM](https://user-images.githubusercontent.com/20260392/205295181-5273ed48-5fdc-4023-935a-2277a8624884.png)



### Changes

- Add a contentWrapper property
- Keep the existing as a default

### Testing

- Testing locally
