### PR TITLE
fix: fix the icon used for error alert variants

### DIFF
--- a/src/components/utils/ControlledAlert/useAlertStyles.tsx
+++ b/src/components/utils/ControlledAlert/useAlertStyles.tsx
@@ -56,7 +56,7 @@ const getTransparentAlertThemes = (alertVariant: AlertVariant): VariantTheming =
       return {
         color: 'red-300',
         backgroundColor: addOpacity(theme.colors['red-300'], 0.3),
-        icon: 'info',
+        icon: 'alert-circle',
       };
     case 'info':
       return {


### PR DESCRIPTION
### Background

We used to display the info icon instead of the alert icon in the error Alerts.

### Changes

- Fix the icon used for the error Alert variant
### Screenshots
![image](https://user-images.githubusercontent.com/15084305/205648519-a5e8f407-2a6b-4b3a-a47e-f9eae840056d.png)

### Testing

- Manually tested
