### PR TITLE
feat: enhance table for customizable row colors

### DIFF
--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -441,3 +441,74 @@ const Example = () => {
 
 <Example />;
 ```
+
+A table can use configured row colors:
+
+```typescript jsx
+// as fetched from the API
+const items = [
+  {
+    id: 1,
+    name: 'AWS DynamoDB Table Encryption Enabled',
+    resourceType: 'AWS.DynamoDB.Table.Snapshot',
+    severity: 'CRITICAL',
+    status: 'Failing',
+    lastModified: '28/04/2019',
+  },
+  {
+    id: 2,
+    name: 'AWS DynamoDB Table Encryption Enabled',
+    resourceType: 'AWS.DynamoDB.Table.Snapshot',
+    severity: 'CRITICAL',
+    status: 'Failing',
+    lastModified: '28/04/2019',
+  },
+  {
+    id: 3,
+    name: 'AWS DynamoDB Table Encryption Enabled',
+    resourceType: 'AWS.DynamoDB.Table.Snapshot',
+    severity: 'CRITICAL',
+    status: 'Failing',
+    lastModified: '28/04/2019',
+  },
+  {
+    id: 4,
+    name: 'AWS DynamoDB Table Encryption Enabled',
+    resourceType: 'AWS.DynamoDB.Table.Snapshot',
+    severity: 'CRITICAL',
+    status: 'Failing',
+    lastModified: '28/04/2019',
+  },
+];
+
+const Example = () => {
+  return (
+    <Card width="100%" height={200} overflowY="scroll">
+      <Table backgroundColor="teal-800" backgroundColorOddRows="teal-700" stickyHeader>
+        <Table.Head>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+            <Table.HeaderCell>Resource Type</Table.HeaderCell>
+            <Table.HeaderCell>Severity</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {items.map(item => (
+            <Table.Row key={item.id}>
+              <Table.Cell truncated>{item.name}</Table.Cell>
+              <Table.Cell truncated title={item.resourceType}>
+                {item.resourceType}
+              </Table.Cell>
+              <Table.Cell>{item.severity}</Table.Cell>
+              <Table.Cell>{item.status}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </Card>
+  );
+};
+
+<Example />;
+```

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Theme } from 'src/theme';
 import Box, { BoxProps, NativeAttributes } from '../Box';
 
 export interface TableProps extends NativeAttributes<'table'> {
@@ -18,6 +19,16 @@ export interface TableProps extends NativeAttributes<'table'> {
    * Whether the header is sticky or should be scrolled long with the content. Defaults to `false`
    */
   stickyHeader?: boolean;
+
+  /** The background color of table header and even-numbered rows for the 'background' rowSeparationStrategy
+   * Defaults to `inherit`
+   */
+  backgroundColor?: keyof Theme['colors'];
+
+  /** The background color of odd-numbered rows for the 'background' rowSeparationStrategy.
+   * Defaults to `navyblue-500`
+   */
+  backgroundColorOddRows?: keyof Theme['colors'];
 }
 
 const TableContext = React.createContext<TableProps>({});
@@ -30,6 +41,8 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
     stickyHeader = false,
     hoverable = false,
     rowSeparationStrategy = 'background',
+    backgroundColor = 'inherit',
+    backgroundColorOddRows = 'navyblue-500',
     ...rest
   },
   ref
@@ -40,8 +53,10 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
       hoverable,
       rowSeparationStrategy,
       stickyHeader,
+      backgroundColor,
+      backgroundColorOddRows,
     }),
-    [size, rowSeparationStrategy, hoverable, stickyHeader]
+    [size, rowSeparationStrategy, hoverable, stickyHeader, backgroundColor, backgroundColorOddRows]
   );
   return (
     <TableContext.Provider value={contextValue}>

--- a/src/components/Table/TableHeaderCell.tsx
+++ b/src/components/Table/TableHeaderCell.tsx
@@ -12,7 +12,13 @@ export type TableHeaderCellProps = NativeAttributes<'th'> & {
 
 const TableHeaderCell = React.forwardRef<HTMLTableHeaderCellElement, TableHeaderCellProps>(
   function TableHeaderCell({ align = 'left', sortDir, ...rest }, ref) {
-    const { size, stickyHeader } = useTable();
+    const { size, stickyHeader, backgroundColor } = useTable();
+
+    // When a value for backgroundColor has been provided, the header, sticky or otherwise, will be
+    // that value. When a value for backgroundColor has not been provided, and the default value of
+    // `inherit` has been applied, sticky headers will have a `navyblue-300` background color.
+    const headerBackgroundColor =
+      stickyHeader && backgroundColor === 'inherit' ? 'navyblue-300' : backgroundColor;
 
     return (
       <Box
@@ -27,7 +33,7 @@ const TableHeaderCell = React.forwardRef<HTMLTableHeaderCellElement, TableHeader
         aria-sort={sortDir ? sortDir : undefined}
         position={stickyHeader ? 'sticky' : undefined}
         top={stickyHeader ? 0 : undefined}
-        backgroundColor={stickyHeader ? 'navyblue-300' : 'inherit'}
+        backgroundColor={headerBackgroundColor}
         verticalAlign="middle"
         {...rest}
       />

--- a/src/components/Table/TableRow.tsx
+++ b/src/components/Table/TableRow.tsx
@@ -22,7 +22,10 @@ const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(function T
       styles = {
         ...styles,
         'tbody > &:nth-of-type(odd)': {
-          backgroundColor: !selected ? ('navyblue-500' as const) : undefined,
+          backgroundColor: !selected ? tableProps.backgroundColorOddRows : undefined,
+        },
+        'tbody > &:nth-of-type(even)': {
+          backgroundColor: !selected ? tableProps.backgroundColor : undefined,
         },
       };
     }


### PR DESCRIPTION
### Background

The table design for the Dashboard work requires an enhancement of the Pounce Table component to allow different row colors to be specified.

### Changes

- The optional props of `backgroundColor` and `backgroundColorOddRows` have been added to allow the customization of row colors.

### Screenshots:

#### Screenshot of expected Dashboard table: 
<img width="663" alt="Screen Shot 2022-12-09 at 11 32 10 AM" src="https://user-images.githubusercontent.com/4212239/206782802-b7972e4d-35d5-4d25-8baa-1a533aecac70.png">

#### Screenshot of example added to Pounce documentation:
<img width="984" alt="Screen Shot 2022-12-09 at 11 27 33 AM" src="https://user-images.githubusercontent.com/4212239/206782851-6015a449-0cee-4281-9ed5-fe3edbc628a4.png">

