### PR TITLE
chore:  added maxContainerHeight for Multicombobox

### DIFF
--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Combobox renders 1`] = `
 
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -386,6 +387,7 @@ exports[`Combobox renders 2`] = `
 
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -586,6 +588,7 @@ exports[`Combobox renders 3`] = `
 
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`DateInput allows passing a custom format 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -240,6 +241,7 @@ exports[`DateInput allows selecting a date with time options 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -473,6 +475,7 @@ exports[`DateInput allows selecting a date with time options in 12h mode 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -706,6 +709,7 @@ exports[`DateInput allows selecting a date with time options in 24h mode 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1081,6 +1085,7 @@ exports[`DateInput can be solid 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1172,6 +1177,7 @@ exports[`DateInput opens the month picker 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1405,6 +1411,7 @@ exports[`DateInput opens the month picker with alignment 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1638,6 +1645,7 @@ exports[`DateInput renders 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DateRangeInput.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`DateRangeInput allows changing time options in 24h mode 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -282,6 +283,7 @@ exports[`DateRangeInput allows passing a custom format 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -550,6 +552,7 @@ exports[`DateRangeInput allows selecting a date range 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -818,6 +821,7 @@ exports[`DateRangeInput allows selecting a preset 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1086,6 +1090,7 @@ exports[`DateRangeInput opens the month picker 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1354,6 +1359,7 @@ exports[`DateRangeInput opens the month picker with empty value 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1622,6 +1628,7 @@ exports[`DateRangeInput opens the month picker with placement 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1890,6 +1897,7 @@ exports[`DateRangeInput renders 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -2296,6 +2304,7 @@ exports[`DateRangeInput renders with solid coloring 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -2426,6 +2435,7 @@ exports[`DateRangeInput renders with time options 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/DateRangeInput/__snapshots__/DoubleTextInput.test.tsx.snap
+++ b/src/components/DateRangeInput/__snapshots__/DoubleTextInput.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -197,6 +198,7 @@ exports[`renders with disabled option 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -392,6 +394,7 @@ exports[`renders with icons 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -678,6 +681,7 @@ exports[`renders with individual values 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -950,6 +954,7 @@ exports[`renders with invalid option 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1054,6 +1059,7 @@ exports[`renders with placeholders 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1246,6 +1252,7 @@ exports[`renders with required option 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/MultiCombobox/MultiCombobox.mdx
+++ b/src/components/MultiCombobox/MultiCombobox.mdx
@@ -304,3 +304,29 @@ const Example8 = () => {
 
 <Example8 />;
 ```
+
+A MultiCombobox can have a maxHeight for the combobox
+
+```typescript jsx
+const Example9 = () => {
+  const [selectedItems, updateSelectedItems] = React.useState([
+    'Lorem ipsum dolor, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+  ]);
+  return (
+    <Box width={0.3}>
+      <MultiCombobox
+        allowAdditions
+        searchable
+        maxContainerHeight={100}
+        label="Choose a car manufacturer"
+        items={[]}
+        onChange={updateSelectedItems}
+        value={selectedItems}
+        placeholder="Search for a manufacturer"
+      />
+    </Box>
+  );
+};
+
+<Example9 />;
+```

--- a/src/components/MultiCombobox/MultiCombobox.tsx
+++ b/src/components/MultiCombobox/MultiCombobox.tsx
@@ -102,6 +102,8 @@ export type MultiComboboxProps<T> = Omit<NativeAttributes<'input'>, 'value' | 'o
   /** The maximum height (in pixels) of the MultiCombobox dropdown. Defaults to 300. */
   maxHeight?: number;
 
+  /** The maximum height (in pixels) of the MultiCombobox dropdown. Defaults to 300. */
+  maxContainerHeight?: number;
   /**
    * A function that runs before a custom item is added by the user. If it returns `true`, then this
    * item will be added to the selection. If not, then this item won't be added
@@ -167,6 +169,7 @@ function MultiCombobox<Item>({
   allowAdditions = false,
   validateAddition = () => true,
   maxHeight = 300,
+  maxContainerHeight,
   maxResults,
   canClearAllAfter,
   invalid,
@@ -341,7 +344,16 @@ function MultiCombobox<Item>({
                 variant={multiComboboxVariant}
                 hidden={hidden}
               >
-                <Flex as="ul" wrap="wrap" align="baseline" pl={3} pr={10} pt={itemsPt} pb="2px">
+                <Flex
+                  as="ul"
+                  wrap="wrap"
+                  align="baseline"
+                  pl={3}
+                  pr={10}
+                  pt={itemsPt}
+                  pb="2px"
+                  maxHeight={maxContainerHeight}
+                >
                   <>
                     {renderContent({ itemToString, removeItem, value, isOpen })}
                     <Box

--- a/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
+++ b/src/components/MultiCombobox/__snapshots__/MultiCombobox.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`MultiCombobox renders 1`] = `
 
 .pounce-4 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -429,6 +430,7 @@ exports[`MultiCombobox renders with clear all option 1`] = `
 
 .pounce-7 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -970,6 +972,7 @@ exports[`MultiCombobox renders with clear all option 2`] = `
 
 .pounce-10 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1658,6 +1661,7 @@ exports[`MultiCombobox renders with variant="solid" 1`] = `
 
 .pounce-4 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`can be disabled 1`] = `
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -220,6 +221,7 @@ exports[`can be invalid 1`] = `
 
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -288,6 +290,7 @@ exports[`can be invalid 1`] = `
 exports[`can be required 1`] = `
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -433,6 +436,7 @@ exports[`can be required 1`] = `
 exports[`renders 1`] = `
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -666,6 +670,7 @@ exports[`renders a solid textarea 1`] = `
 
 .pounce-2 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`renders 1`] = `
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -166,6 +167,7 @@ exports[`renders 1`] = `
 exports[`renders with different type 1`] = `
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -329,6 +331,7 @@ exports[`renders with different type 1`] = `
 exports[`renders with disabled option 1`] = `
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -495,6 +498,7 @@ exports[`renders with disabled option 1`] = `
 exports[`renders with icons 1`] = `
 .pounce-4 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -994,6 +998,7 @@ exports[`renders with invalid option 1`] = `
 
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1066,6 +1071,7 @@ exports[`renders with invalid option 1`] = `
 exports[`renders with prefix 1`] = `
 .pounce-4 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1250,6 +1256,7 @@ exports[`renders with prefix 1`] = `
 exports[`renders with required option 1`] = `
 .pounce-3 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -1415,6 +1422,7 @@ exports[`renders with required option 1`] = `
 exports[`renders with suffix 1`] = `
 .pounce-4 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;

--- a/src/components/utils/Input/InputControl.tsx
+++ b/src/components/utils/Input/InputControl.tsx
@@ -47,6 +47,7 @@ const InputControl: React.FC<InputControlProps> = ({
   return (
     <Box
       minHeight={47}
+      overflow="auto"
       position="relative"
       border="1px solid"
       transition="border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms"

--- a/src/components/utils/Input/__snapshots__/InputControl.test.tsx.snap
+++ b/src/components/utils/Input/__snapshots__/InputControl.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`can be disabled 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -44,6 +45,7 @@ exports[`can be disabled 1`] = `
 exports[`can be hidden 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -86,6 +88,7 @@ exports[`can be hidden 1`] = `
 exports[`can be invalid 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -122,6 +125,7 @@ exports[`can be invalid 1`] = `
 exports[`can be required 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -162,6 +166,7 @@ exports[`can be required 1`] = `
 exports[`can be solid 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
@@ -202,6 +207,7 @@ exports[`can be solid 1`] = `
 exports[`renders 1`] = `
 .pounce-0 {
   min-height: 47px;
+  overflow: auto;
   position: relative;
   border: 1px solid;
   -webkit-transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;


### PR DESCRIPTION
### Background

We want to provide options to force the multicombobox input area to have a maxHeight and be scrollable.

### Changes

- Added `overflow:auto` to underlying to `InputControl`
- Added a prop `maxContainerHeight` for Multicombobox
- Added mdx example

### Screencast


https://user-images.githubusercontent.com/14179917/208915617-db192f23-e4f5-42db-b764-6159839e692a.mov


