### PR TITLE
fix(combobox): toggle menu with button

### DIFF
--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithTheme, fireClickAndMouseEvents } from 'test-utils';
+import { renderWithTheme, fireClickAndMouseEvents, waitMs } from 'test-utils';
 import React from 'react';
 import Combobox, { ComboboxProps } from './index';
 import userEvent from '@testing-library/user-event';
@@ -75,5 +75,28 @@ describe('Combobox', () => {
     userEvent.click(getByPlaceholderText('Select manufacturer'));
     userEvent.click(getByPlaceholderText('another input'));
     expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles the dropdown menu by clicking the caret button', async () => {
+    const { getByText, getByPlaceholderText, getByRole, queryByText } = renderWithTheme(
+      <ControlledCombobox searchable />
+    );
+    const toggleMenuButton = getByRole('button', { name: 'Toggle Menu' });
+    userEvent.click(getByPlaceholderText('Select manufacturer'));
+    expect(getByText('Toyota')).toBeInTheDocument();
+    fireClickAndMouseEvents(getByText('Toyota'));
+    await waitMs(300);
+    // Check that menu is closed after selection
+    expect(queryByText('Ford')).not.toBeInTheDocument();
+
+    // Click toggle menu button and expect menu to open
+    fireClickAndMouseEvents(toggleMenuButton);
+    await waitMs(300);
+    expect(queryByText('Ford')).toBeInTheDocument();
+
+    // Click toggle menu button again and expect menu to close
+    fireClickAndMouseEvents(toggleMenuButton);
+    await waitMs(300);
+    expect(queryByText('Ford')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Background

This PR allows the combobox to be reopened by clicking the caret button when the `searchable` prop is `true`. Without this update, then user must click outside of the component after selecting an option before they can reopen the dropdown menu.
https://user-images.githubusercontent.com/109993923/211393280-0c6f5bc3-2605-4dc4-8f2c-7de26210de8f.mov

### Changes

- Added an onMouseDown handler for the `searchable` version that toggles the menu when the toggle menu button is clicked
- Added a test

### Testing

- run `npm start` to start the docs locally
- scroll down to the Combobox component and find the "searchable" demo
- open the dropdown and select an item
- immediately click the toggle menu button without blurring out of the combobox component
- ensure the menu opens
- click the toggle menu button again and ensure if closes the menu
